### PR TITLE
Fix: Unreliable Welcome redirects

### DIFF
--- a/src/components/dialogs/ChangePassword.tsx
+++ b/src/components/dialogs/ChangePassword.tsx
@@ -1,7 +1,7 @@
 // External libraries
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
-import { User, useUser } from "@supabase/auth-helpers-react";
+import { useSupabaseClient, useUser } from "@supabase/auth-helpers-react";
 
 // SK Components
 import {
@@ -23,8 +23,9 @@ import { DialogProps } from "@utils/types/common";
 import { useToggle } from "@utils/hooks/toggle";
 
 const ChangePassword = ({ show, onClose }: DialogProps): JSX.Element => {
+  const supabase = useSupabaseClient();
+  const user = useUser()!;
   const { t } = useTranslation("account");
-  const user = useUser() as User;
 
   const [loading, toggleLoading] = useToggle();
 
@@ -64,7 +65,7 @@ const ChangePassword = ({ show, onClose }: DialogProps): JSX.Element => {
         onClose={toggleShowDiscard}
         onSubmit={async () => {
           toggleLoading();
-          await changePassword(form, user);
+          await changePassword(supabase, form, user);
           toggleLoading();
           onClose();
         }}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -36,9 +36,9 @@ export async function middleware(req: NextRequest) {
   if (pageRole == "not-protected") return NextResponse.next();
 
   // (@SiravitPhokeed)
-  // I’m not using the Supabase Server Client because that isn’t supported here.
-  // The way we're approaching middleware is very much not intended by Supabase.
-  // As a workaround, we’re fetching directly from the Supabase API.
+  // I’m not using the Supabase Server Client because that isn’t supported
+  // here. The way we’re approaching middleware is very much not intended by
+  // Supabase. As a workaround, we’re fetching directly from the Supabase API.
 
   // Fetch user from Supabase
   let user = null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -72,8 +72,6 @@ export async function middleware(req: NextRequest) {
   const userIsOnboarded: boolean = user ? user.onboarded : false;
   const userIsAdmin: boolean = user ? user.is_admin : false;
 
-  console.log({ userRole, userIsOnboarded, userIsAdmin });
-
   // Decide on destination based on user and page protection type
   let destination: string | null = null;
   // Disallow public users from visiting private pages

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -92,7 +92,7 @@ const Login: NextPage = () => {
     }
 
     // Onboard the user if this is their first log in
-    if (user!.onboarded) router.push("/welcome");
+    if (!user!.onboarded) router.push("/welcome");
 
     // Role redirect
     if (user!.role == "teacher") router.push("/teach");

--- a/src/pages/account/login.tsx
+++ b/src/pages/account/login.tsx
@@ -10,7 +10,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import { useState } from "react";
 
-import { User, useSupabaseClient } from "@supabase/auth-helpers-react";
+import { useSupabaseClient } from "@supabase/auth-helpers-react";
 
 // SK Components
 import {
@@ -27,9 +27,11 @@ import {
 // Components
 import ForgotPasswordDialog from "@components/dialogs/account/ForgotPassword";
 
+// Backend
+import { getUserMetadata } from "@utils/backend/account";
+
 // Types
 import { LangCode } from "@utils/types/common";
-import { Role } from "@utils/types/person";
 
 // Helpers
 import { createTitleStr } from "@utils/helpers/title";
@@ -71,32 +73,33 @@ const Login: NextPage = () => {
     if (!validate()) return;
 
     // Log in user in Supabase
-    const { data, error } = await supabase.auth.signInWithPassword({
+    const {
+      data: { session },
+      error,
+    } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
-    if (error) {
+    if (!session || error) {
       toggleLoading();
       return;
     }
 
-    const { data: user, error: userError } = await supabase
-      .from("users")
-      .select("role, onboarded")
-      .match({ id: data.user?.id })
-      .limit(1)
-      .single();
-    if (userError) {
+    const { data: metadata, error: metadataError } = await getUserMetadata(
+      supabase,
+      session.user.id
+    );
+    if (metadataError) {
       toggleLoading();
       return;
     }
 
     // Onboard the user if this is their first log in
-    if (!user!.onboarded) router.push("/welcome");
+    if (!metadata!.onboarded) router.push("/welcome");
 
     // Role redirect
-    if (user!.role == "teacher") router.push("/teach");
-    if (user!.role == "student") router.push("/learn");
+    if (metadata!.role == "teacher") router.push("/teach");
+    if (metadata!.role == "student") router.push("/learn");
   }
 
   return (

--- a/src/utils/backend/account.ts
+++ b/src/utils/backend/account.ts
@@ -23,9 +23,9 @@ export async function getUserMetadata(
 
   return {
     data: {
-      role: JSON.parse(data.role) as Role,
-      isAdmin: data.is_admin,
-      onboarded: data.onboarded,
+      role: JSON.parse(data!.role) as Role,
+      isAdmin: data!.is_admin,
+      onboarded: data!.onboarded,
     },
     error: null,
   };

--- a/src/utils/backend/account.ts
+++ b/src/utils/backend/account.ts
@@ -1,8 +1,38 @@
 // External libraries
 import { User } from "@supabase/supabase-js";
-import { supabase } from "@utils/supabase-client";
+
+// Types
+import { BackendDataReturn, DatabaseClient } from "@utils/types/common";
+import { Role, UserMetadata } from "@utils/types/person";
+
+export async function getUserMetadata(
+  supabase: DatabaseClient,
+  id: string
+): Promise<BackendDataReturn<UserMetadata, null>> {
+  const { data, error } = await supabase
+    .from("users")
+    .select("role, is_admin, onboarded")
+    .match({ id })
+    .limit(1)
+    .single();
+
+  if (error) {
+    console.error(error);
+    return { data: null, error };
+  }
+
+  return {
+    data: {
+      role: data.role as Role,
+      isAdmin: data.is_admin,
+      onboarded: data.onboarded,
+    },
+    error: null,
+  };
+}
 
 export async function changePassword(
+  supabase: DatabaseClient,
   form: {
     originalPassword: string;
     newPassword: string;

--- a/src/utils/backend/account.ts
+++ b/src/utils/backend/account.ts
@@ -23,7 +23,7 @@ export async function getUserMetadata(
 
   return {
     data: {
-      role: data.role as Role,
+      role: JSON.parse(data.role) as Role,
       isAdmin: data.is_admin,
       onboarded: data.onboarded,
     },

--- a/src/utils/types/person.ts
+++ b/src/utils/types/person.ts
@@ -3,6 +3,12 @@ import { MultiLangObj, MultiLangString } from "./common";
 import { Contact } from "./contact";
 import { SubjectGroup, SubjectWNameAndCode } from "./subject";
 
+export type UserMetadata = {
+  role: Role;
+  isAdmin: boolean;
+  onboarded: boolean;
+};
+
 export type Person = {
   id: number;
   prefix: MultiLangString;


### PR DESCRIPTION
**Features**
- `getUserMetaData` function

**Fixes**
- Change Password has no RLS support
- Redirect from Log in to Welcome/Learn/Teach is unreliable and can erroneously redirect all users to Welcome
- Middleware redirects are unreliable and can erroneously redirect all users to Welcome
