### PR TITLE
Beta Release 0.6.2 (Hotfix)

### DIFF
--- a/components/common/PageHeader.tsx
+++ b/components/common/PageHeader.tsx
@@ -57,9 +57,9 @@ const PageHeader: FC<
               appearance="text"
               icon={<MaterialIcon icon="arrow_backward" />}
               alt={t("action.navigation")}
-              onClick={onBack}
-              href={parentURL}
-              element={Link}
+              {...(onBack
+                ? { onClick: onBack }
+                : { href: parentURL, element: Link })}
             />
           ) : (
             <Button


### PR DESCRIPTION
**Fixes**
- The `element` prop for the Back button in Page Header is determined to be `Link`, despite the fact that it should be `button` if `onBack` is determined
  - This causes Welcome to throw