### PR TITLE
[0.8.4] School Session State

### DIFF
--- a/components/classes/LookupClassCard.tsx
+++ b/components/classes/LookupClassCard.tsx
@@ -31,7 +31,6 @@ import { useEffect, useState } from "react";
  * list.
  *
  * @param classroom The Classroom to display.
- * @param period The currently relevant Schedule Item for this Classroom.
  * @param selected The ID of the currently selected Classroom.
  * @param onClick The function to call when the card is clicked. Should select this Classroom.
  */
@@ -141,8 +140,10 @@ const LookupClassCard: StylableFC<{
             classroom.id === selected && `sm:group-focus:border-primary`,
           )}
         >
-          {period ? (
+          {[4, 5].includes(currentPeriodNumber) ? (
             <MaterialIcon icon="fastfood" className="text-tertiary" />
+          ) : period ? (
+            <MaterialIcon icon="hourglass" className="text-outline" />
           ) : (
             <MaterialIcon icon="home" className="text-secondary" />
           )}

--- a/components/home/HomeGlance.tsx
+++ b/components/home/HomeGlance.tsx
@@ -123,7 +123,7 @@ const HomeGlance: StylableFC<{
           homeroom: new Date().setHours(...HOMEROOM_START),
         }[attendanceEvent],
       )
-    : currentPeriod?.content.length
+    : currentPeriod
       ? differenceInSeconds(
           now,
           getTodaySetToPeriodTime(currentPeriod.start_time),
@@ -144,7 +144,7 @@ const HomeGlance: StylableFC<{
         now,
         { roundingMethod: "ceil" },
       )
-    : currentPeriod?.content.length
+    : currentPeriod
       ? differenceInMinutes(
           getTodaySetToPeriodTime(
             currentPeriod.start_time + currentPeriod.duration - 1,

--- a/components/home/HomeGlance.tsx
+++ b/components/home/HomeGlance.tsx
@@ -5,11 +5,17 @@ import GlancePeriods from "@/components/home/GlanceSubjects";
 import cn from "@/utils/helpers/cn";
 import getLocaleString from "@/utils/helpers/getLocaleString";
 import getCurrentPeriod from "@/utils/helpers/schedule/getCurrentPeriod";
-import getCurrentSchoolSessionState from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
+import getCurrentSchoolSessionState, {
+  ASSEMBLY_START,
+  HOMEROOM_START,
+  SCHEDULE_START,
+  SchoolSessionState,
+} from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
 import getTodaySetToPeriodTime from "@/utils/helpers/schedule/getTodaySetToPeriodTime";
 import useLocale from "@/utils/helpers/useLocale";
 import useNow from "@/utils/helpers/useNow";
 import within from "@/utils/helpers/within";
+import { AttendanceEvent } from "@/utils/types/attendance";
 import { Classroom } from "@/utils/types/classroom";
 import { StylableFC } from "@/utils/types/common";
 import { UserRole } from "@/utils/types/person";
@@ -19,31 +25,11 @@ import {
   transition,
   useAnimationConfig,
 } from "@suankularb-components/react";
-import {
-  differenceInMinutes,
-  differenceInSeconds,
-  isFuture,
-  isPast,
-} from "date-fns";
+import { differenceInMinutes, differenceInSeconds } from "date-fns";
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
 import { Trans, useTranslation } from "next-i18next";
 import { camel, list } from "radash";
 import { useMemo } from "react";
-
-/**
- * The start time of assembly.
- */
-const ASSEMBLY_START: Parameters<Date["setHours"]> = [7, 30, 0, 0];
-
-/**
- * The start time of homeroom.
- */
-const HOMEROOM_START: Parameters<Date["setHours"]> = [8, 0, 0, 0];
-
-/**
- * The start time of period 1.
- */
-const PERIOD_START: Parameters<Date["setHours"]> = [8, 30, 0, 0];
 
 /**
  * A glanceable banner dynamically updated by the current and upcoming schedule
@@ -108,15 +94,16 @@ const HomeGlance: StylableFC<{
   // Note: `differenceInSeconds` and `differenceInMinutes` operate by
   // [first param] - [second param]
 
-  // The sequence of periods is as follows:
-  //   1. Assembly   07:30 - 08:00
-  //   2. Homeroom   08:00 - 08:30
-  //   3. Periods    08:30 onwards
+  const schoolSessionState = getCurrentSchoolSessionState();
 
-  const attendanceEvent = isFuture(new Date().setHours(...PERIOD_START))
-    ? isFuture(new Date().setHours(...HOMEROOM_START))
-      ? "assembly"
-      : "homeroom"
+  /**
+   * The current Attendance Event, if any.
+   */
+  const attendanceEvent = [
+    SchoolSessionState.assembly,
+    SchoolSessionState.homeroom,
+  ].includes(schoolSessionState)
+    ? (schoolSessionState as AttendanceEvent)
     : null;
 
   // The edges of periods relative to current time, used in calculating the
@@ -128,12 +115,13 @@ const HomeGlance: StylableFC<{
    *
    * Also support assembly and homeroom.
    */
-  const secondsSinceStart = isFuture(new Date().setHours(...PERIOD_START))
+  const secondsSinceStart = attendanceEvent
     ? differenceInSeconds(
         now,
-        isPast(new Date().setHours(...HOMEROOM_START))
-          ? new Date().setHours(...HOMEROOM_START)
-          : new Date().setHours(...ASSEMBLY_START),
+        {
+          assembly: new Date().setHours(...ASSEMBLY_START),
+          homeroom: new Date().setHours(...HOMEROOM_START),
+        }[attendanceEvent],
       )
     : currentPeriod?.content.length
       ? differenceInSeconds(
@@ -150,10 +138,11 @@ const HomeGlance: StylableFC<{
   const minutesTilEnd = attendanceEvent
     ? differenceInMinutes(
         {
-          assembly: new Date().setHours(...PERIOD_START),
-          homeroom: new Date().setHours(...HOMEROOM_START),
+          assembly: new Date().setHours(...HOMEROOM_START),
+          homeroom: new Date().setHours(...SCHEDULE_START),
         }[attendanceEvent],
         now,
+        { roundingMethod: "ceil" },
       )
     : currentPeriod?.content.length
       ? differenceInMinutes(
@@ -197,13 +186,12 @@ const HomeGlance: StylableFC<{
    */
   const classProgress =
     (secondsSinceStart /
-      // If class hasn’t started yet, it’s probably assembly or homeroom
-      ((getCurrentSchoolSessionState() === "before"
-        ? // Assembly and homeroom are each 30 minutes long
-          30
-        : // If there is a current period, use the duration of that period
-          // (A period is 50 minutes long)
-          (currentPeriod?.duration || 1) * 50) *
+      // If there is a current period, use the duration of that period
+      // (A period is 50 minutes long)
+      ((schoolSessionState === SchoolSessionState.schedule
+        ? (currentPeriod?.duration || 1) * 50
+        : // Assembly and homeroom are each 30 minutes long
+          30) *
         // There are 60 seconds in a minute
         60)) *
     // Convert decimal to percentage
@@ -214,11 +202,8 @@ const HomeGlance: StylableFC<{
    * and upcoming schedule items to be the most relevant.
    */
   const displayType = (() => {
-    // If it’s between 07:30 and 08:00, display that it’s assembly time
-    // If it’s between 08:00 and 08:30, display that it’s homeroom time
-    if (isFuture(new Date().setHours(...PERIOD_START)))
-      if (isFuture(new Date().setHours(...HOMEROOM_START))) return "assembly";
-      else return "homeroom";
+    // If it’s assembly or homeroom, display that
+    if (attendanceEvent) return attendanceEvent;
 
     // If there are no periods today, don’t display anything
     if (!todayRow.length) return "none";

--- a/components/lookup/people/CurrentPeriodCard.tsx
+++ b/components/lookup/people/CurrentPeriodCard.tsx
@@ -1,7 +1,9 @@
 // Imports
 import cn from "@/utils/helpers/cn";
 import getLocaleString from "@/utils/helpers/getLocaleString";
-import getCurrentSchoolSessionState from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
+import getCurrentSchoolSessionState, {
+  SchoolSessionState,
+} from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
 import getTodaySetToPeriodTime from "@/utils/helpers/schedule/getTodaySetToPeriodTime";
 import useLocale from "@/utils/helpers/useLocale";
 import useNow from "@/utils/helpers/useNow";
@@ -64,7 +66,7 @@ const CurrentPeriodCard: StylableFC<{
   // Fetch the current period once the percentage reaches 100%
   useEffect(() => {
     // If school is not in session, don’t fetch
-    if (getCurrentSchoolSessionState() !== "in-session") {
+    if (getCurrentSchoolSessionState() !== SchoolSessionState.schedule) {
       setLoading(false);
       return;
     }

--- a/components/schedule/Schedule.tsx
+++ b/components/schedule/Schedule.tsx
@@ -10,7 +10,9 @@ import SubjectsInChargeCard from "@/components/schedule/SubjectsInChargeCard";
 import ScheduleContext from "@/contexts/ScheduleContext";
 import cn from "@/utils/helpers/cn";
 import getCurrentPeriod from "@/utils/helpers/schedule/getCurrentPeriod";
-import getCurrentSchoolSessionState from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
+import getCurrentSchoolSessionState, {
+  SchoolSessionState,
+} from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
 import isInPeriod from "@/utils/helpers/schedule/isInPeriod";
 import useNow from "@/utils/helpers/useNow";
 import { StylableFC } from "@/utils/types/common";
@@ -62,7 +64,7 @@ const Schedule: StylableFC<{
   useEffect(() => {
     const schedule = scheduleRef.current;
     if (!schedule) return;
-    if (getCurrentSchoolSessionState() !== "in-session") return;
+    if (getCurrentSchoolSessionState() !== SchoolSessionState.schedule) return;
     schedule.scrollTo({ top: 0, left: (getCurrentPeriod() - 2) * 104 });
   }, []);
 
@@ -103,7 +105,9 @@ const Schedule: StylableFC<{
           className="relative overflow-x-auto overflow-y-hidden pb-1"
         >
           {/* Now indicator line */}
-          {getCurrentSchoolSessionState() === "in-session" && <NowLine />}
+          {getCurrentSchoolSessionState() === SchoolSessionState.schedule && (
+            <NowLine />
+          )}
 
           <ul className="flex w-fit flex-col gap-2 px-4 py-2 sm:px-0">
             {/* Period numbers and start-end times */}
@@ -165,4 +169,3 @@ const Schedule: StylableFC<{
 };
 
 export default Schedule;
-

--- a/utils/backend/schedule/getRelevantPeriodOfClass.ts
+++ b/utils/backend/schedule/getRelevantPeriodOfClass.ts
@@ -3,7 +3,9 @@ import getCurrentSemester from "@/utils/helpers/getCurrentSemester";
 import logError from "@/utils/helpers/logError";
 import mergeDBLocales from "@/utils/helpers/mergeDBLocales";
 import getCurrentPeriod from "@/utils/helpers/schedule/getCurrentPeriod";
-import getCurrentSchoolSessionState from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
+import getCurrentSchoolSessionState, {
+  SchoolSessionState,
+} from "@/utils/helpers/schedule/getCurrentSchoolSessionState";
 import { BackendReturn, DatabaseClient } from "@/utils/types/backend";
 import { SchedulePeriod } from "@/utils/types/schedule";
 import { group, pick, sift, unique } from "radash";
@@ -23,7 +25,7 @@ export default async function getRelevantPeriodOfClass(
   classroomID: string,
 ): Promise<BackendReturn<SchedulePeriod | null> & { isCurrent: boolean }> {
   // If the school is not in session, stop early and return null
-  if (getCurrentSchoolSessionState() !== "in-session")
+  if (getCurrentSchoolSessionState() !== SchoolSessionState.schedule)
     return { data: null, error: null, isCurrent: false };
 
   // Fetch today’s Schedule Items of the Classroom

--- a/utils/backend/schedule/getRelevantPeriodOfClass.ts
+++ b/utils/backend/schedule/getRelevantPeriodOfClass.ts
@@ -106,6 +106,6 @@ export default async function getRelevantPeriodOfClass(
   return {
     data: currentPeriod || nextPeriod || null,
     error: null,
-    isCurrent: currentPeriod !== null,
+    isCurrent: currentPeriod !== undefined,
   };
 }

--- a/utils/helpers/schedule/getCurrentSchoolSessionState.ts
+++ b/utils/helpers/schedule/getCurrentSchoolSessionState.ts
@@ -1,36 +1,74 @@
-// Imports
-import getPeriodBoundaryTime from "@/utils/helpers/schedule/getPeriodBoundaryTime";
-import { isFuture, isPast, isSaturday, isSunday } from "date-fns";
+import { isFuture, isSaturday, isSunday } from "date-fns";
 
 /**
- * Check if school is in session now.
- *
- * @returns
- * `before` — it’s morning and school haven’t started;
- * `in-session` — school is in session;
- * `after` —  it’s after school or it’s the weekend.
+ * The start time of assembly.
  */
-export default function getCurrentSchoolSessionState():
-  | "before"
-  | "in-session"
-  | "after" {
-  // Weekend check
-  if (isSaturday(new Date()) || isSunday(new Date())) return "after";
+export const ASSEMBLY_START: Parameters<Date["setHours"]> = [7, 30, 0, 0];
 
-  // Time check
-  return isFuture(
-    new Date().setHours(
-      getPeriodBoundaryTime(0).hours,
-      getPeriodBoundaryTime(0).min,
-    ),
-  )
-    ? "before"
-    : isPast(
-        new Date().setHours(
-          getPeriodBoundaryTime(10).hours,
-          getPeriodBoundaryTime(10).min,
-        ),
-      )
-    ? "after"
-    : "in-session";
+/**
+ * The start time of homeroom.
+ */
+export const HOMEROOM_START: Parameters<Date["setHours"]> = [8, 0, 0, 0];
+
+/**
+ * The start time of period 1.
+ */
+export const SCHEDULE_START: Parameters<Date["setHours"]> = [8, 30, 0, 0];
+
+/**
+ * The start time of period 10.
+ */
+export const SCHEDULE_END: Parameters<Date["setHours"]> = [16, 50, 0, 0];
+
+export enum SchoolSessionState {
+  before = "before",
+  assembly = "assembly",
+  homeroom = "homeroom",
+  schedule = "schedule",
+  after = "after",
+}
+
+/**
+ * Get the current School Session State, calculated from the current time.
+ *
+ * @returns The current School Session State.
+ *
+ * @see {@link SchoolSessionState School Session State}
+ */
+export default function getCurrentSchoolSessionState(): SchoolSessionState {
+  // Note: replace this variable to test different times. Useful if you want to
+  // test Home Glance.
+  const now = new Date();
+
+  // Here’s a diagram of how School Session States are laid out:
+
+  // +--------------------------------+
+  // | <-B                            | where B is SchoolSessionState.before
+  // |   | ASSEMBLY_START             |
+  // |   <-A->                        | where A is SchoolSessionState.assembly
+  // |       | HOMEROOM_START         |
+  // |       <-H->                    | where H is SchoolSessionState.homeroom
+  // |           | SCHEDULE_START     |
+  // |           <-S->                | where S is SchoolSessionState.schedule
+  // |               | SCHEDULE_END   |
+  // |               E->              | where E is SchoolSessionState.after
+  // +--------------------------------+
+
+  // Weekends
+  if (isSaturday(now) || isSunday(now)) return SchoolSessionState.after;
+
+  // Before Schedule starts
+  if (isFuture(now.setHours(...ASSEMBLY_START)))
+    return SchoolSessionState.before;
+  if (isFuture(now.setHours(...HOMEROOM_START)))
+    return SchoolSessionState.assembly;
+  if (isFuture(now.setHours(...SCHEDULE_START)))
+    return SchoolSessionState.homeroom;
+
+  // During scheduled time
+  if (isFuture(now.setHours(...SCHEDULE_END)))
+    return SchoolSessionState.schedule;
+
+  // After Schedule ends
+  return SchoolSessionState.after;
 }


### PR DESCRIPTION
![](https://github.com/suankularb-wittayalai-school/mysk-frontend/assets/26425747/512c7d31-faf7-4683-a4ad-b3cdaace867b)

**Features**
- `getCurrentSchoolSessionState` now returns a `SchoolSessionState` enum member, which now includes `assembly` and `homeroom`

**Fixes**
- Relevant period in [Lookup Class Card](https://pr.mysk.school/classes) is always treated as current
  Fixes #204
- Assembly and Homeroom surfaced in Home Glance during weekends
  Fixes #205
- Glance Countdown is broken during Assembly, Homeroom, and lunch
  - Start time was wrong for Assembly and Homeroom
  - Stayed at 0 minutes for lunch

**Notes**
All issues resolved in this pull request are time-dependent. Reviewers should **change the date and time of their simulator/device to experiment**. As always, a preview is available at https://pr.mysk.school/.