### PR TITLE
[0.10.0] Elective Integration in Schedule

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -374,7 +374,7 @@ const Layout: FC<
       {/* Page loading indicator */}
       <Progress
         appearance="linear"
-        alt={t("pageIsLoading")}
+        alt={t("pageLoading")}
         visible={pageIsLoading}
         className="!z-[100]"
       />

--- a/components/elective/ChooseButton.tsx
+++ b/components/elective/ChooseButton.tsx
@@ -15,18 +15,18 @@ import { useContext } from "react";
  *
  * @param sessionCode The session code of the Elective Subject to choose.
  * @param enrolledID The session code of the Elective Subject the Student is currently enrolled in.
- * @param inEnrollmentPeriod Whether the time now is in an Enrollment Period.
+ * @param disabled Whether the Button is disabled.
  * @param onSucess Triggers after the Student has successfully chosen the Elective Subject.
  */
 const ChooseButton: StylableFC<{
   sessionCode: number | null;
   enrolledID: number | null;
-  inEnrollmentPeriod?: boolean;
+  disabled?: boolean;
   onSucess?: () => void;
 }> = ({
   sessionCode,
   enrolledID,
-  inEnrollmentPeriod,
+  disabled: forceDisabled,
   onSucess,
   style,
   className,
@@ -41,8 +41,8 @@ const ChooseButton: StylableFC<{
 
   const [loading, toggleLoading] = useToggle();
   const disabled =
-    // Disallow choosing if not in time window.
-    !inEnrollmentPeriod ||
+    // Disallow choosing if forced to be disabled.
+    forceDisabled ||
     // Disallow choosing if none is selected.
     !sessionCode ||
     // Disallow choosing if already enrolled in the same Elective Subject.

--- a/components/elective/ElectiveListItem.tsx
+++ b/components/elective/ElectiveListItem.tsx
@@ -76,7 +76,10 @@ const ElectiveListItem: StylableFC<{
                 },
               }}
             />
-            <span>{" • " + getLocaleString(electiveSubject.code, locale)}</span>
+            <span>
+              {electiveSubject.teachers.length > 0 && " • "}
+              {getLocaleString(electiveSubject.code, locale)}
+            </span>
           </>
         }
         className="!grid *:truncate"

--- a/components/home/glance/ElectiveGrid.tsx
+++ b/components/home/glance/ElectiveGrid.tsx
@@ -1,10 +1,7 @@
-import SingleSubjectDetails from "@/components/home/glance/SingleSubjectDetails";
+import ElectiveGridItem from "@/components/home/glance/ElectiveGridItem";
 import cn from "@/utils/helpers/cn";
-import getLocaleString from "@/utils/helpers/getLocaleString";
-import useLocale from "@/utils/helpers/useLocale";
 import { StylableFC } from "@/utils/types/common";
 import { SchedulePeriod } from "@/utils/types/schedule";
-import { Card, CardHeader } from "@suankularb-components/react";
 import { list } from "radash";
 
 /**
@@ -14,51 +11,40 @@ import { list } from "radash";
  */
 const ElectiveGrid: StylableFC<{
   period: SchedulePeriod;
-}> = ({ period, style, className }) => {
-  const locale = useLocale();
-
-  return (
-    <div
-      className={cn(`-mx-4 snap-x snap-mandatory overflow-x-auto
-        md:snap-none`)}
+}> = ({ period, style, className }) => (
+  <div
+    className={cn(`-mx-4 snap-x snap-mandatory overflow-x-auto
+      md:snap-none`)}
+  >
+    <ul
+      role="list"
+      style={style}
+      className={cn(
+        `flex w-fit grid-cols-2 flex-row gap-2 px-3 md:grid md:w-auto`,
+        className,
+      )}
     >
-      <ul
-        role="list"
-        style={style}
-        className={cn(
-          `flex w-fit grid-cols-2 flex-row gap-2 px-3 md:grid md:w-auto`,
-          className,
-        )}
-      >
-        {period.content.map((subject) => (
-          // Period Content Item
-          <Card
-            key={subject.id}
-            appearance="filled"
-            className={cn(`w-[calc(100vw-3.5rem)] max-w-96 snap-start
-              scroll-ml-3 !rounded-lg sm:w-96 sm:max-w-full md:w-auto`)}
-          >
-            <CardHeader
-              title={getLocaleString(subject.subject.name, locale)}
-              subtitle={getLocaleString(subject.subject.code, locale)}
-              className="!px-3 !py-2"
-            />
-            <SingleSubjectDetails period={subject} className="grow p-2 pt-0" />
-          </Card>
-        ))}
-      </ul>
+      {period.content.map((subject) => (
+        // Period Content Item
+        <ElectiveGridItem
+          key={subject.id}
+          subject={subject}
+          className={cn(`w-[calc(100vw-3.5rem)] max-w-96 snap-start scroll-ml-3
+            sm:w-96 sm:max-w-full md:w-auto`)}
+        />
+      ))}
+    </ul>
 
-      {/* Pages indicator */}
-      <div
-        className={cn(`sticky left-0 flex flex-row justify-center gap-0.5 pt-1
-          sm:hidden`)}
-      >
-        {list(period.content.length - 1).map((index) => (
-          <div key={index} className="h-1 w-1 rounded-full bg-outline" />
-        ))}
-      </div>
+    {/* Pages indicator */}
+    <div
+      className={cn(`sticky left-0 flex flex-row justify-center gap-0.5 pt-1
+        sm:hidden`)}
+    >
+      {list(period.content.length - 1).map((index) => (
+        <div key={index} className="h-1 w-1 rounded-full bg-outline" />
+      ))}
     </div>
-  );
-};
+  </div>
+);
 
 export default ElectiveGrid;

--- a/components/home/glance/ElectiveGridItem.tsx
+++ b/components/home/glance/ElectiveGridItem.tsx
@@ -1,0 +1,39 @@
+import SingleSubjectDetails from "@/components/home/glance/SingleSubjectDetails";
+import cn from "@/utils/helpers/cn";
+import getLocaleString from "@/utils/helpers/getLocaleString";
+import useLocale from "@/utils/helpers/useLocale";
+import { StylableFC } from "@/utils/types/common";
+import { PeriodContentItem } from "@/utils/types/schedule";
+import { Card, CardHeader } from "@suankularb-components/react";
+
+/**
+ * A single Period Content Item in an Elective Grid.
+ *
+ * @param subject The Period Content Item to display.
+ */
+const ElectiveGridItem: StylableFC<{
+  subject: PeriodContentItem;
+}> = ({ subject, style, className }) => {
+  const locale = useLocale();
+
+  return (
+    <Card
+      appearance="filled"
+      element="li"
+      style={style}
+      className={cn(`!rounded-lg !bg-surface-bright`, className)}
+    >
+      <CardHeader
+        title={getLocaleString(subject.subject.name, locale)}
+        subtitle={getLocaleString(subject.subject.code, locale)}
+        className="!px-3 !py-2"
+      />
+      <SingleSubjectDetails
+        period={subject}
+        className="grow p-2 pt-0 *:!bg-surface-container"
+      />
+    </Card>
+  );
+};
+
+export default ElectiveGridItem;

--- a/components/home/glance/ElectiveGridItem.tsx
+++ b/components/home/glance/ElectiveGridItem.tsx
@@ -4,16 +4,18 @@ import getLocaleString from "@/utils/helpers/getLocaleString";
 import useLocale from "@/utils/helpers/useLocale";
 import { StylableFC } from "@/utils/types/common";
 import { PeriodContentItem } from "@/utils/types/schedule";
-import { Card, CardHeader } from "@suankularb-components/react";
+import { Card, CardHeader, MaterialIcon } from "@suankularb-components/react";
 
 /**
  * A single Period Content Item in an Elective Grid.
  *
  * @param subject The Period Content Item to display.
+ * @param enrolled Whether the respective Elective Subject is currently enrolled.
  */
 const ElectiveGridItem: StylableFC<{
   subject: PeriodContentItem;
-}> = ({ subject, style, className }) => {
+  enrolled?: boolean;
+}> = ({ subject, enrolled, style, className }) => {
   const locale = useLocale();
 
   return (
@@ -21,13 +23,25 @@ const ElectiveGridItem: StylableFC<{
       appearance="filled"
       element="li"
       style={style}
-      className={cn(`!rounded-lg !bg-surface-bright`, className)}
+      className={cn(
+        `!rounded-lg`,
+        enrolled ? `!bg-primary` : `!bg-surface-bright`,
+        className,
+      )}
     >
-      <CardHeader
-        title={getLocaleString(subject.subject.name, locale)}
-        subtitle={getLocaleString(subject.subject.code, locale)}
-        className="!px-3 !py-2"
-      />
+      <div
+        className={cn(
+          `grid grid-cols-[1fr,2.75rem] items-center`,
+          enrolled && `text-on-primary`,
+        )}
+      >
+        <CardHeader
+          title={getLocaleString(subject.subject.name, locale)}
+          subtitle={getLocaleString(subject.subject.code, locale)}
+          className="!px-3 !py-2"
+        />
+        {enrolled && <MaterialIcon icon="done" />}
+      </div>
       <SingleSubjectDetails
         period={subject}
         className="grow p-2 pt-0 *:!bg-surface-container"

--- a/components/home/glance/ScheduleGlance.tsx
+++ b/components/home/glance/ScheduleGlance.tsx
@@ -62,7 +62,11 @@ const ScheduleGlance: StylableFC<{
       className={cn(`flex flex-col gap-3 p-4 pt-3`, className)}
     >
       <motion.div
-        key={displayPeriod?.id || displayType}
+        key={
+          displayPeriod?.id
+            ? displayPeriod.id + displayPeriod.content.length
+            : displayType
+        }
         layout="position"
         initial={{ opacity: 0, y: -10 }}
         animate={{ opacity: 1, y: 0 }}

--- a/components/home/glance/SingleSubjectDetails.tsx
+++ b/components/home/glance/SingleSubjectDetails.tsx
@@ -23,7 +23,10 @@ const SingleSubjectDetails: StylableFC<{
   return (
     <div
       style={style}
-      className={cn(`grid grid-cols-2 gap-2 *:space-y-1`, className)}
+      className={cn(
+        `grid grid-cols-2 gap-2 *:space-y-1 *:bg-surface-bright`,
+        className,
+      )}
     >
       {/* Teachers */}
       <InformationCard title={t("details.teachers.title")}>

--- a/components/person/PeopleChipSet.tsx
+++ b/components/person/PeopleChipSet.tsx
@@ -25,6 +25,7 @@ const PersonChipSet: FC<
     ComponentProps<typeof WithPersonDetails>["person"]
   >(people[0]);
 
+  if (!selectedPerson) return <ul />;
   return (
     <WithPersonDetails
       open={detailsOpen}

--- a/components/schedule/AddPeriodDialog.tsx
+++ b/components/schedule/AddPeriodDialog.tsx
@@ -5,7 +5,7 @@ import SnackbarContext from "@/contexts/SnackbarContext";
 import createScheduleItem from "@/utils/backend/schedule/createScheduleItem";
 import cn from "@/utils/helpers/cn";
 import getLocaleString from "@/utils/helpers/getLocaleString";
-import { getSubjectName } from "@/utils/helpers/getSubjectName";
+import { formatSubjectPeriodName } from "@/utils/helpers/schedule/formatSubjectPeriodName";
 import periodDurationToWidth from "@/utils/helpers/schedule/periodDurationToWidth";
 import useForm from "@/utils/helpers/useForm";
 import useLocale from "@/utils/helpers/useLocale";
@@ -178,7 +178,7 @@ const AddPeriodDialog: StylableFC<{
                 transition={transition(DURATION.short4, EASING.standard)}
                 className="skc-text skc-text--body-small"
               >
-                {getSubjectName(form.duration, subject, locale)}
+                {formatSubjectPeriodName(form.duration, subject, locale)}
               </motion.span>
             </AnimatePresence>
           </motion.div>

--- a/components/schedule/ElectivePeriod.tsx
+++ b/components/schedule/ElectivePeriod.tsx
@@ -7,7 +7,7 @@ import { formatSubjectPeriodName } from "@/utils/helpers/schedule/formatSubjectP
 import periodDurationToWidth from "@/utils/helpers/schedule/periodDurationToWidth";
 import useLocale from "@/utils/helpers/useLocale";
 import { StylableFC } from "@/utils/types/common";
-import { Student } from "@/utils/types/person";
+import { Student, UserRole } from "@/utils/types/person";
 import { SchedulePeriod } from "@/utils/types/schedule";
 import { Interactive, MaterialIcon, Text } from "@suankularb-components/react";
 import va from "@vercel/analytics";
@@ -33,11 +33,14 @@ const ElectivePeriod: StylableFC<{
   const { t } = useTranslation("schedule");
 
   const mysk = useMySKClient();
-  const chosenElective = period.content.find(
-    (subject) =>
-      (mysk.person as Student)?.chosen_elective?.code.th ===
-      subject.subject.code.th,
-  );
+  const chosenElective =
+    (mysk.person?.role === UserRole.student &&
+      period.content.find(
+        (subject) =>
+          (mysk.person as Student)?.chosen_elective?.code.th ===
+          subject.subject.code.th,
+      )) ||
+    null;
 
   const [detailsOpen, setDetailsOpen] = useState(false);
 

--- a/components/schedule/ElectivePeriod.tsx
+++ b/components/schedule/ElectivePeriod.tsx
@@ -9,7 +9,7 @@ import useLocale from "@/utils/helpers/useLocale";
 import { StylableFC } from "@/utils/types/common";
 import { Student } from "@/utils/types/person";
 import { SchedulePeriod } from "@/utils/types/schedule";
-import { Interactive, Text } from "@suankularb-components/react";
+import { Interactive, MaterialIcon, Text } from "@suankularb-components/react";
 import va from "@vercel/analytics";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
@@ -17,6 +17,10 @@ import { useState } from "react";
 /**
  * When many Schedule Periods overlap, they are grouped into a single Elective
  * Period.
+ *
+ * If the Student has chosen an Elective, Elective Period imitates a Subject
+ * Period of that Elective. The More Indicator is shown to distinguish it from a
+ * Subject Period.
  *
  * @param period The Schedule Period to render.
  * @param isInSession Whether the Schedule Period is currently in session.
@@ -56,8 +60,7 @@ const ElectivePeriod: StylableFC<{
       >
         <Interactive
           className={cn(
-            `flex h-full flex-col justify-center rounded-sm
-            bg-[--_background-color] px-4 py-2 text-left
+            `h-full rounded-sm bg-[--_background-color]
             text-[--_foreground-color] transition-shadow focus:shadow-2`,
             isInSession ? "shadow-1 hover:shadow-2" : "hover:shadow-1",
           )}
@@ -68,7 +71,7 @@ const ElectivePeriod: StylableFC<{
           }}
         >
           {chosenElective ? (
-            <>
+            <div className="grid px-4 py-2 text-left">
               <Text type="title-medium">
                 {formatSubjectPeriodName(
                   period.duration,
@@ -79,11 +82,19 @@ const ElectivePeriod: StylableFC<{
               <Text type="body-small">
                 <HoverList people={chosenElective.teachers} />
               </Text>
-            </>
+            </div>
           ) : (
-            <Text type="title-medium" className="!leading-none">
-              {t("schedule.elective")}
-            </Text>
+            <div
+              className={cn(
+                `flex items-center justify-center`,
+                period.duration < 2 ? `flex-col pt-1` : `flex-row gap-1.5`,
+              )}
+            >
+              <MaterialIcon icon="collections_bookmark" size={20} />
+              <Text type={period.duration < 2 ? "title-small" : "title-medium"}>
+                {t("schedule.elective")}
+              </Text>
+            </div>
           )}
         </Interactive>
         <MoreIndicator

--- a/components/schedule/ElectivePeriod.tsx
+++ b/components/schedule/ElectivePeriod.tsx
@@ -1,17 +1,16 @@
+import HoverList from "@/components/person/HoverList";
 import ElectivePeriodDetails from "@/components/schedule/ElectivePeriodDetails";
+import MoreIndicator from "@/components/schedule/MoreIndicator";
+import useMySKClient from "@/utils/backend/mysk/useMySKClient";
 import cn from "@/utils/helpers/cn";
+import { formatSubjectPeriodName } from "@/utils/helpers/schedule/formatSubjectPeriodName";
 import periodDurationToWidth from "@/utils/helpers/schedule/periodDurationToWidth";
+import useLocale from "@/utils/helpers/useLocale";
 import { StylableFC } from "@/utils/types/common";
+import { Student } from "@/utils/types/person";
 import { SchedulePeriod } from "@/utils/types/schedule";
-import {
-  DURATION,
-  EASING,
-  Interactive,
-  Text,
-  transition,
-} from "@suankularb-components/react";
+import { Interactive, Text } from "@suankularb-components/react";
 import va from "@vercel/analytics";
-import { motion } from "framer-motion";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
 
@@ -26,49 +25,72 @@ const ElectivePeriod: StylableFC<{
   period: SchedulePeriod;
   isInSession?: boolean;
 }> = ({ period, isInSession, style, className }) => {
-  // Translation
+  const locale = useLocale();
   const { t } = useTranslation("schedule");
 
-  // Animation
+  const mysk = useMySKClient();
+  const chosenElective = period.content.find(
+    (subject) =>
+      (mysk.person as Student)?.chosen_elective?.code.th ===
+      subject.subject.code.th,
+  );
 
-  // Dialog control
-  const [detailsOpen, setDetailsOpen] = useState<boolean>(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   return (
     <>
-      {!detailsOpen ? (
-        <motion.li
-          layoutId={`elective-period-${period.id}`}
-          transition={transition(DURATION.medium2, EASING.standard)}
-          style={style}
-          className={cn(`relative`, className)}
+      <li
+        style={style}
+        className={cn(
+          `group relative`,
+          isInSession
+            ? `[--_background-color:var(--tertiary-container)]
+              [--_foreground-color:var(--on-tertiary-container)]`
+            : chosenElective
+              ? `[--_background-color:var(--secondary-container)]
+                [--_foreground-color:var(--on-secondary-container)]`
+              : `[--_background-color:var(--surface-variant)]
+                [--_foreground-color:var(--primary)]`,
+          className,
+        )}
+      >
+        <Interactive
+          className={cn(
+            `flex h-full flex-col justify-center rounded-sm
+            bg-[--_background-color] px-4 py-2 text-left
+            text-[--_foreground-color] transition-shadow focus:shadow-2`,
+            isInSession ? "shadow-1 hover:shadow-2" : "hover:shadow-1",
+          )}
+          style={{ width: periodDurationToWidth(period.duration) }}
+          onClick={() => {
+            va.track("Open Period Details");
+            setDetailsOpen(true);
+          }}
         >
-          <Interactive
-            className={cn(
-              `flex h-full flex-col justify-center rounded-sm px-4 py-2
-              text-left transition-shadow hover:shadow-1 focus:shadow-2`,
-              isInSession
-                ? `bg-tertiary-container text-on-tertiary-container shadow-1
-                  hover:shadow-2`
-                : `bg-surface-variant text-primary`,
-            )}
-            style={{ width: periodDurationToWidth(period.duration) }}
-            onClick={() => {
-              va.track("Open Period Details");
-              setDetailsOpen(true);
-            }}
-          >
+          {chosenElective ? (
+            <>
+              <Text type="title-medium">
+                {formatSubjectPeriodName(
+                  period.duration,
+                  chosenElective.subject,
+                  locale,
+                )}
+              </Text>
+              <Text type="body-small">
+                <HoverList people={chosenElective.teachers} />
+              </Text>
+            </>
+          ) : (
             <Text type="title-medium" className="!leading-none">
               {t("schedule.elective")}
             </Text>
-          </Interactive>
-        </motion.li>
-      ) : (
-        <li
-          style={{ width: periodDurationToWidth(period.duration) }}
-          className="h-14 w-24"
+          )}
+        </Interactive>
+        <MoreIndicator
+          style={{ height: 3, left: 12, bottom: -4, right: 12 }}
+          className="absolute top-auto"
         />
-      )}
+      </li>
       <ElectivePeriodDetails
         period={period}
         open={detailsOpen}

--- a/components/schedule/ElectivePeriod.tsx
+++ b/components/schedule/ElectivePeriod.tsx
@@ -74,7 +74,7 @@ const ElectivePeriod: StylableFC<{
           }}
         >
           {chosenElective ? (
-            <div className="grid px-4 py-2 text-left">
+            <div className="grid px-4 py-2 text-left *:truncate">
               <Text type="title-medium">
                 {formatSubjectPeriodName(
                   period.duration,

--- a/components/schedule/ElectivePeriodDetails.tsx
+++ b/components/schedule/ElectivePeriodDetails.tsx
@@ -44,7 +44,8 @@ const ElectivePeriodDetails: StylableFC<{
       title={t("title")}
       onClose={onClose}
       className={cn(
-        `[&>:last-child]:max-h-96`,
+        `!bg-surface-container-high [&>:first-child]:!bg-surface-container-high
+        [&>:last-child]:max-h-96`,
         // Workaround: Full-screen Dialog currently can’t appear within another
         // Full-screen Dialog. The component was made back when <dialog> wasn’t
         // really a thing yet.

--- a/components/schedule/MoreIndicator.tsx
+++ b/components/schedule/MoreIndicator.tsx
@@ -1,0 +1,38 @@
+import MoreIndicatorEdge from "@/components/schedule/MoreIndicatorEdge";
+import cn from "@/utils/helpers/cn";
+import { StylableFC } from "@/utils/types/common";
+
+/**
+ * This indicator lets the user know that there are more Elective Periods that
+ * are not shown.
+ */
+const MoreIndicator: StylableFC = ({ style, className }) => (
+  <div
+    style={style}
+    className={cn(
+      `bg-[--_background-color] text-[--_background-color] *:absolute
+      before:absolute before:inset-0 before:bg-[--_foreground-color]
+      before:opacity-[.12]`,
+      className,
+    )}
+  >
+    {/* Left side */}
+    <MoreIndicatorEdge style={{ top: -1, left: -7 }} />
+    <MoreIndicatorEdge
+      style={{ top: -1, left: -7 }}
+      className="text-[--_foreground-color] opacity-[.12]"
+    />
+
+    {/* Right side */}
+    <MoreIndicatorEdge
+      style={{ top: -1, right: -7 }}
+      className="-scale-x-100" // Flip the right side.
+    />
+    <MoreIndicatorEdge
+      style={{ top: -1, right: -7 }}
+      className="-scale-x-100 text-[--_foreground-color] opacity-[.12]"
+    />
+  </div>
+);
+
+export default MoreIndicator;

--- a/components/schedule/MoreIndicatorEdge.tsx
+++ b/components/schedule/MoreIndicatorEdge.tsx
@@ -1,0 +1,28 @@
+import { StylableFC } from "@/utils/types/common";
+
+/**
+ * One side of the More Indicator under Elective Period.
+ *
+ * ```plaintext
+ * __     ________     __                                                 __
+ * \_ and ________ and _/ combines into the Indicator. The edge is shaped \_.
+ * ```
+ */
+const MoreIndicatorEdge: StylableFC = ({ style, className }) => (
+  <svg
+    width={7}
+    height={4}
+    viewBox="0 0 7 4"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    style={style}
+    className={className}
+  >
+    <path
+      d="M0.441406 0.582031C1.2447 0.85298 2.1051 0.999852 2.99979 0.999852L7
+        1L6.99979 3.99961C4.28604 3.99961 1.88788 2.64838 0.441406 0.582031Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+export default MoreIndicatorEdge;

--- a/components/schedule/NowLine.tsx
+++ b/components/schedule/NowLine.tsx
@@ -1,4 +1,5 @@
 import cn from "@/utils/helpers/cn";
+import { SCHEDULE_START } from "@/utils/helpers/schedule/schoolSessionStateAt";
 import useNow from "@/utils/helpers/useNow";
 import { StylableFC } from "@/utils/types/common";
 import { differenceInSeconds } from "date-fns";
@@ -29,7 +30,7 @@ const NowLine: StylableFC = ({ style, className }) => {
         // School starts at 08:30, so we use the number of minutes from then to
         // now
         transform: `translateX(${
-          differenceInSeconds(now, new Date().setHours(8, 30), {
+          differenceInSeconds(now, new Date(now).setHours(...SCHEDULE_START), {
             roundingMethod: "round",
           }) *
           (104 / 3000)

--- a/components/schedule/SubjectPeriod.tsx
+++ b/components/schedule/SubjectPeriod.tsx
@@ -7,7 +7,7 @@ import lengthenScheduleItem from "@/utils/backend/schedule/lengthenScheduleItem"
 import moveScheduleItem from "@/utils/backend/schedule/moveScheduleItem";
 import cn from "@/utils/helpers/cn";
 import getLocaleString from "@/utils/helpers/getLocaleString";
-import { getSubjectName } from "@/utils/helpers/getSubjectName";
+import { formatSubjectPeriodName } from "@/utils/helpers/schedule/formatSubjectPeriodName";
 import periodDurationToWidth from "@/utils/helpers/schedule/periodDurationToWidth";
 import positionPxToPeriod from "@/utils/helpers/schedule/positionPxToPeriod";
 import useLocale from "@/utils/helpers/useLocale";
@@ -336,7 +336,7 @@ const SubjectPeriod: FC<{
                   />
                 )}
               >
-                {getSubjectName(period.duration, period.subject, locale)}
+                {formatSubjectPeriodName(period.duration, period.subject, locale)}
               </Text>
             )}
 
@@ -344,7 +344,7 @@ const SubjectPeriod: FC<{
             {(view === "student" || !menuOpen || extending || loading) && (
               <Text type="body-small">
                 {view === "teacher" ? (
-                  getSubjectName(period.duration, period.subject, locale)
+                  formatSubjectPeriodName(period.duration, period.subject, locale)
                 ) : (
                   <HoverList people={period.teachers} />
                 )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "mysk",
       "version": "0.9.4",
       "dependencies": {
-        "@suankularb-components/react": "^3.3.1",
+        "@suankularb-components/react": "^3.3.2",
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/auth-helpers-react": "^0.5.0",
-        "@supabase/supabase-js": "^2.42.7",
+        "@supabase/supabase-js": "^2.43.0",
         "@tanstack/react-table": "^8.16.0",
         "@vercel/analytics": "^1.2.2",
         "chart.js": "^4.4.2",
@@ -19,7 +19,7 @@
         "date-fns-tz": "^3.1.3",
         "framer-motion": "^10.18.0",
         "google-auth-library": "^9.9.0",
-        "i18next": "^23.11.2",
+        "i18next": "^23.11.3",
         "next": "^14.2.3",
         "next-auth": "^4.24.7",
         "next-i18next": "^15.3.0",
@@ -100,20 +100,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
-      "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+      "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.4",
+        "@babel/generator": "^7.24.5",
         "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.24.4",
-        "@babel/parser": "^7.24.4",
+        "@babel/helper-module-transforms": "^7.24.5",
+        "@babel/helpers": "^7.24.5",
+        "@babel/parser": "^7.24.5",
         "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -137,11 +137,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.4.tgz",
-      "integrity": "sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
       "dependencies": {
-        "@babel/types": "^7.24.0",
+        "@babel/types": "^7.24.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -196,18 +196,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
-      "integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.5.tgz",
+      "integrity": "sha512-uRc4Cv8UQWnE4NXlYTIIdM7wfFkOqlFztcC/gVXDKohKoVB3OyonfelUBaJzSwpBntZ2KYGF/9S7asCHsXwW6g==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-member-expression-to-functions": "^7.23.0",
+        "@babel/helper-member-expression-to-functions": "^7.24.5",
         "@babel/helper-optimise-call-expression": "^7.22.5",
         "@babel/helper-replace-supers": "^7.24.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-split-export-declaration": "^7.24.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -296,11 +296,11 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.5.tgz",
+      "integrity": "sha512-4owRteeihKWKamtqg4JmWSsEZU445xpFRXPEwp44HbgbxdWlUV1b4Agg4lkA806Lil5XM/e+FJyS0vj5T6vmcA==",
       "dependencies": {
-        "@babel/types": "^7.23.0"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -318,15 +318,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+      "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
+        "@babel/helper-module-imports": "^7.24.3",
+        "@babel/helper-simple-access": "^7.24.5",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/helper-validator-identifier": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
-      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -387,11 +387,11 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+      "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -409,11 +409,11 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -444,37 +444,37 @@
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
-      "integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.5.tgz",
+      "integrity": "sha512-/xxzuNvgRl4/HLNKvnFwdhdgN3cpLxgLROeLDl83Yx0AJ1SGvq1ak0OszTOjDfiB8Vx03eJbeDWh9r+jCCWttw==",
       "dependencies": {
-        "@babel/helper-function-name": "^7.22.5",
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.22.19"
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/template": "^7.24.0",
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.4.tgz",
-      "integrity": "sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+      "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
       "dependencies": {
         "@babel/template": "^7.24.0",
-        "@babel/traverse": "^7.24.1",
-        "@babel/types": "^7.24.0"
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
-      "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -559,12 +559,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.4.tgz",
-      "integrity": "sha512-qpl6vOOEEzTLLcsuqYYo8yDtrTocmu2xkGvgNebvPjT9DTtfFYGmgDqY+rBYXNlqL4s9qLDn6xkrJv4RxAPiTA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.5.tgz",
+      "integrity": "sha512-LdXRi1wEMTrHVR4Zc9F8OewC3vdm5h4QB6L71zy6StmYeqGi1b3ttIO8UC+BfZKcH9jdr4aI249rBkm+3+YvHw==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -908,11 +908,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.4.tgz",
-      "integrity": "sha512-nIFUZIpGKDf9O9ttyRXpHFpKC+X3Y5mtshZONuEUYBomAKoM4y029Jr+uB1bHGPhNmK8YXHevDtKDOLmtRrp6g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.5.tgz",
+      "integrity": "sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -953,17 +953,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.1.tgz",
-      "integrity": "sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.5.tgz",
+      "integrity": "sha512-gWkLP25DFj2dwe9Ck8uwMOpko4YsqyfZJrOmqqcegeDYEbp7rmn4U6UQZNj08UF6MaX39XenSpKRCvpDRBtZ7Q==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/helper-replace-supers": "^7.24.1",
-        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-split-export-declaration": "^7.24.5",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -997,11 +997,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.1.tgz",
-      "integrity": "sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
+      "integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1296,14 +1296,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.1.tgz",
-      "integrity": "sha512-XjD5f0YqOtebto4HGISLNfiNMTTs6tbkFf2TOqJlYKYmbo+mN9Dnpl4SRoofiziuOWMIyq3sZEUqLo3hLITFEA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.5.tgz",
+      "integrity": "sha512-7EauQHszLGM3ay7a161tTQH7fj+3vVM/gThlz5HpFtnygTxjrlvoeq7MPVA1Vy9Q555OB8SnAOsMkLShNkkrHA==",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.24.1"
+        "@babel/plugin-transform-parameters": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1343,11 +1343,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.1.tgz",
-      "integrity": "sha512-n03wmDt+987qXwAgcBlnUUivrZBPZ8z1plL0YvgQalLm+ZE5BMhGm94jhxXtA1wzv1Cu2aaOv1BM9vbVttrzSg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.5.tgz",
+      "integrity": "sha512-xWCkmwKT+ihmA6l7SSTpk8e4qQl/274iNbSKRRS8mpqFR32ksy36+a+LWY8OXCCEefF8WFlnOHVsaDI2231wBg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
@@ -1359,11 +1359,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.1.tgz",
-      "integrity": "sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.5.tgz",
+      "integrity": "sha512-9Co00MqZ2aoky+4j2jhofErthm6QVLKbpQrvz20c3CH9KQCLHyNB+t2ya4/UrRpQGR+Wrwjg9foopoeSdnHOkA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1388,13 +1388,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.1.tgz",
-      "integrity": "sha512-pTHxDVa0BpUbvAgX3Gat+7cSciXqUcY9j2VZKTbSB6+VQGpNgNO9ailxTGHSXlqOnX1Hcx1Enme2+yv7VqP9bg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.5.tgz",
+      "integrity": "sha512-JM4MHZqnWR04jPMujQDTBVRnqxpLLpx2tkn7iPn+Hmsc0Gnb79yvRWOkvqFOx3Z7P7VxiRIR22c4eGSNj87OBQ==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.24.1",
-        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-create-class-features-plugin": "^7.24.5",
+        "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
       "engines": {
@@ -1505,11 +1505,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.1.tgz",
-      "integrity": "sha512-CBfU4l/A+KruSUoW+vTQthwcAdwuqbpRNB8HQKlZABwHRhsdHZ9fezp4Sn18PeAlYxTNiLMlx4xUBV3AWfg1BA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.5.tgz",
+      "integrity": "sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1578,15 +1578,15 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.4.tgz",
-      "integrity": "sha512-7Kl6cSmYkak0FK/FXjSEnLJ1N9T/WA2RkMhu17gZ/dsxKJUuTYNIylahPTzqpLyJN4WhDif8X0XK1R8Wsguo/A==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.5.tgz",
+      "integrity": "sha512-UGK2ifKtcC8i5AI4cH+sbLLuLc2ktYSFJgBAXorKAsHUZmrQ1q6aQ6i3BvU24wWs2AAKqQB6kq3N9V9Gw1HiMQ==",
       "dependencies": {
         "@babel/compat-data": "^7.24.4",
         "@babel/helper-compilation-targets": "^7.23.6",
-        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-plugin-utils": "^7.24.5",
         "@babel/helper-validator-option": "^7.23.5",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.4",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.5",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.1",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.1",
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.1",
@@ -1613,12 +1613,12 @@
         "@babel/plugin-transform-async-generator-functions": "^7.24.3",
         "@babel/plugin-transform-async-to-generator": "^7.24.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.24.1",
-        "@babel/plugin-transform-block-scoping": "^7.24.4",
+        "@babel/plugin-transform-block-scoping": "^7.24.5",
         "@babel/plugin-transform-class-properties": "^7.24.1",
         "@babel/plugin-transform-class-static-block": "^7.24.4",
-        "@babel/plugin-transform-classes": "^7.24.1",
+        "@babel/plugin-transform-classes": "^7.24.5",
         "@babel/plugin-transform-computed-properties": "^7.24.1",
-        "@babel/plugin-transform-destructuring": "^7.24.1",
+        "@babel/plugin-transform-destructuring": "^7.24.5",
         "@babel/plugin-transform-dotall-regex": "^7.24.1",
         "@babel/plugin-transform-duplicate-keys": "^7.24.1",
         "@babel/plugin-transform-dynamic-import": "^7.24.1",
@@ -1638,13 +1638,13 @@
         "@babel/plugin-transform-new-target": "^7.24.1",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.1",
         "@babel/plugin-transform-numeric-separator": "^7.24.1",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.1",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.5",
         "@babel/plugin-transform-object-super": "^7.24.1",
         "@babel/plugin-transform-optional-catch-binding": "^7.24.1",
-        "@babel/plugin-transform-optional-chaining": "^7.24.1",
-        "@babel/plugin-transform-parameters": "^7.24.1",
+        "@babel/plugin-transform-optional-chaining": "^7.24.5",
+        "@babel/plugin-transform-parameters": "^7.24.5",
         "@babel/plugin-transform-private-methods": "^7.24.1",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.1",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.5",
         "@babel/plugin-transform-property-literals": "^7.24.1",
         "@babel/plugin-transform-regenerator": "^7.24.1",
         "@babel/plugin-transform-reserved-words": "^7.24.1",
@@ -1652,7 +1652,7 @@
         "@babel/plugin-transform-spread": "^7.24.1",
         "@babel/plugin-transform-sticky-regex": "^7.24.1",
         "@babel/plugin-transform-template-literals": "^7.24.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.24.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.24.5",
         "@babel/plugin-transform-unicode-escapes": "^7.24.1",
         "@babel/plugin-transform-unicode-property-regex": "^7.24.1",
         "@babel/plugin-transform-unicode-regex": "^7.24.1",
@@ -1698,9 +1698,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1722,18 +1722,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
-      "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.1",
-        "@babel/generator": "^7.24.1",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.24.1",
-        "@babel/types": "^7.24.0",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/types": "^7.24.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1750,12 +1750,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2711,9 +2711,9 @@
       "dev": true
     },
     "node_modules/@suankularb-components/react": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@suankularb-components/react/-/react-3.3.1.tgz",
-      "integrity": "sha512-Q/ZlIfIplMY1I5rLsVhbuE81Sb3V2uhFk/eWQMylWW/ZAZ07bNcRPIpY3LxY48/hWTsczVBeQDfiFWmnhBNmrg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@suankularb-components/react/-/react-3.3.2.tgz",
+      "integrity": "sha512-p0B90GJB8TZ3SyvgLo2rcp5u4/Y00YKRLAFROw367ixJ5YT28ZRH7gwwpV1jetJxVWkZzIpc7UjC9jsOM4WJ1A==",
       "dependencies": {
         "radash": "^11.0.0"
       },
@@ -2798,9 +2798,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.4.tgz",
-      "integrity": "sha512-wdq+2hZpgw0r2ldRs87d3U08Y8BrsO1bZxPNqbImpYshAEkusDz4vufR8KaqujKxqewmXS6YnUhuRVdvSEIKCA==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.5.tgz",
+      "integrity": "sha512-TEHlGwNGGmKPdeMtca1lFTYCedrhTAv3nZVoSjrKQ+wkMmaERuCe57zkC5KSWFzLYkb5FVHW8Hrr+PX1DDwplQ==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",
@@ -2817,15 +2817,15 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.42.7",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.42.7.tgz",
-      "integrity": "sha512-BEIEYe5KJpzd8Z3k4CKyjNuBmgSihDdE8MJO/Fg7O5h/lQg8qOp1MMWLWPP5aVKt4TYled/W82ePNJflqc2JbQ==",
+      "version": "2.43.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.43.0.tgz",
+      "integrity": "sha512-e/MXc/7HPEXayWoxDTv+xqxF5+wlpH3/+UoP3TXLH0OiShICTbyJfmRgn/GCNw7E7+DlUq+3c48q12FtGWrVmQ==",
       "dependencies": {
         "@supabase/auth-js": "2.64.1",
         "@supabase/functions-js": "2.3.1",
         "@supabase/node-fetch": "2.6.15",
         "@supabase/postgrest-js": "1.15.2",
-        "@supabase/realtime-js": "2.9.4",
+        "@supabase/realtime-js": "2.9.5",
         "@supabase/storage-js": "2.5.5"
       }
     },
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001612",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
-      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
+      "version": "1.0.30001614",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz",
+      "integrity": "sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==",
       "funding": [
         {
           "type": "opencollective",
@@ -4639,9 +4639,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.750",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.750.tgz",
-      "integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA=="
+      "version": "1.4.752",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.752.tgz",
+      "integrity": "sha512-P3QJreYI/AUTcfBVrC4zy9KvnZWekViThgQMX/VpJ+IsOBbcX5JFpORM4qWapwWQ+agb2nYAOyn/4PMXOk0m2Q=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -4773,9 +4773,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
-      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.2.tgz",
+      "integrity": "sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==",
       "peer": true
     },
     "node_modules/es-object-atoms": {
@@ -5727,11 +5727,12 @@
       }
     },
     "node_modules/globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dependencies": {
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5980,9 +5981,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "23.11.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.2.tgz",
-      "integrity": "sha512-qMBm7+qT8jdpmmDw/kQD16VpmkL9BdL+XNAK5MNbNFaf1iQQq35ZbPrSlqmnNPOSUY4m342+c0t0evinF5l7sA==",
+      "version": "23.11.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.3.tgz",
+      "integrity": "sha512-Pq/aSKowir7JM0rj+Wa23Kb6KKDUGno/HjG+wRQu0PxoTbpQ4N89MAT0rFGvXmLkRLNMb1BbBOKGozl01dabzg==",
       "funding": [
         {
           "type": "individual",
@@ -8450,9 +8451,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.1.tgz",
-      "integrity": "sha512-tS24spDe/zXhWbNPErCHs/AGOzbKGHT+ybSBqmdLm8WZ1xXLWvH8Qn71QPAlqVhd0qUTWjy+Kl9JmISgDdEjsA==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -8735,9 +8736,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.20.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.2.tgz",
-      "integrity": "sha512-S1d1ernz3KQ+Y2awUxKakpfOg2CEmJmwOP+6igPx6dgr6pgDvenqYviyokWso2rhHvGtTlWWnJDa7RaPbQerTg==",
+      "version": "10.21.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.21.0.tgz",
+      "integrity": "sha512-aQAIxtzWEwH8ou+OovWVSVNlFImL7xUCwJX3YMqA3U8iKCNC34999fFOnWjYNsylgfPgMexpbk7WYOLtKr/mxg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10150,9 +10151,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.30.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
-      "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
+      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -11081,14 +11082,14 @@
       }
     },
     "node_modules/workbox-build/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "uri-js": "^4.4.1"
       },
       "funding": {
         "type": "github",
@@ -11393,9 +11394,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11418,9 +11419,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
-      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
+      "integrity": "sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@suankularb-components/react": "^3.3.1",
+    "@suankularb-components/react": "^3.3.2",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/auth-helpers-react": "^0.5.0",
-    "@supabase/supabase-js": "^2.42.7",
+    "@supabase/supabase-js": "^2.43.0",
     "@tanstack/react-table": "^8.16.0",
     "@vercel/analytics": "^1.2.2",
     "chart.js": "^4.4.2",
@@ -21,7 +21,7 @@
     "date-fns-tz": "^3.1.3",
     "framer-motion": "^10.18.0",
     "google-auth-library": "^9.9.0",
-    "i18next": "^23.11.2",
+    "i18next": "^23.11.3",
     "next": "^14.2.3",
     "next-auth": "^4.24.7",
     "next-i18next": "^15.3.0",

--- a/pages/learn/elective.tsx
+++ b/pages/learn/elective.tsx
@@ -161,7 +161,7 @@ const LearnElectivesPage: CustomPage<{
               <ChooseButton
                 sessionCode={selectedID}
                 enrolledID={enrolledID}
-                inEnrollmentPeriod={inEnrollmentPeriod}
+                disabled={!inEnrollmentPeriod}
                 className="!pointer-events-auto"
               />
             </Actions>
@@ -236,7 +236,7 @@ const LearnElectivesPage: CustomPage<{
       >
         <ElectiveDetailsCard
           electiveSubject={selectedElective}
-          enrolledID={enrolledID}
+          enrolledID={inEnrollmentPeriod ? enrolledID : null}
           onChooseSuccess={() => setDetailsOpen(false)}
           className={cn(`!mx-0 h-full !bg-surface-container-highest
             *:!rounded-b-none`)}

--- a/public/static/locales/en-US/schedule.json
+++ b/public/static/locales/en-US/schedule.json
@@ -46,7 +46,7 @@
   "schedule": {
     "yourSubjects": "Your subjects",
     "additionGuide": "Drag a subject into the period when you teach that subject, then fill in the rest of the information.",
-    "elective": "Elective period",
+    "elective": "Elective",
     "hoverMenu": {
       "add": "Add period here",
       "more": "View details",

--- a/utils/helpers/schedule/formatSubjectPeriodName.ts
+++ b/utils/helpers/schedule/formatSubjectPeriodName.ts
@@ -1,4 +1,3 @@
-// Imports
 import getLocaleString from "@/utils/helpers/getLocaleString";
 import { LangCode } from "@/utils/types/common";
 import { SchedulePeriod } from "@/utils/types/schedule";
@@ -9,21 +8,18 @@ import { Subject } from "@/utils/types/subject";
  *
  * @param duration The length of this Period.
  * @param subject The Subject name object.
+ * @param locale The locale to format the Subject name in.
  *
  * @returns A formatted Subject name to be shown in a Subject Period.
  */
-export function getSubjectName(
+export function formatSubjectPeriodName(
   duration: SchedulePeriod["duration"],
   subject: Pick<Subject, "name" | "short_name">,
   locale: LangCode,
 ) {
-  return duration < 2
-    ? // If short period, use short name
-      subject.short_name[locale] ||
-        subject.short_name.th ||
-        // If no short name, use name
-        subject.name[locale] ||
-        subject.name.th
-    : // If long period, use name
-      getLocaleString(subject.name, locale);
+  // Show the short name for a single period, if available.
+  if (duration < 2 && subject.short_name)
+    return getLocaleString(subject.short_name, locale);
+  // Otherwise, show the full name.
+  return getLocaleString(subject.name, locale);
 }

--- a/utils/helpers/schedule/useScheduleGlance.ts
+++ b/utils/helpers/schedule/useScheduleGlance.ts
@@ -43,8 +43,7 @@ export default function useScheduleGlance(schedule: Schedule, role: UserRole) {
 
   // Determine relevant periods every second
   const todayRow = useMemo(
-    // () => (!isWeekend(now) ? schedule.content[now.getDay() - 1].content : []),
-    () => (!isWeekend(now) ? schedule.content[4].content : []),
+    () => (!isWeekend(now) ? schedule.content[now.getDay() - 1].content : []),
     [schedule, now.getDay()],
   );
 

--- a/utils/helpers/schedule/useScheduleGlance.ts
+++ b/utils/helpers/schedule/useScheduleGlance.ts
@@ -1,3 +1,4 @@
+import useMySKClient from "@/utils/backend/mysk/useMySKClient";
 import getTodaySetToPeriodTime from "@/utils/helpers/schedule/getTodaySetToPeriodTime";
 import {
   ASSEMBLY_START,
@@ -8,8 +9,8 @@ import {
 import useNow from "@/utils/helpers/useNow";
 import within from "@/utils/helpers/within";
 import { AttendanceEvent } from "@/utils/types/attendance";
-import { UserRole } from "@/utils/types/person";
-import { Schedule } from "@/utils/types/schedule";
+import { Student, UserRole } from "@/utils/types/person";
+import { Schedule, SchedulePeriod } from "@/utils/types/schedule";
 import { differenceInMinutes, differenceInSeconds, isWeekend } from "date-fns";
 import { mapValues } from "radash";
 import { useMemo } from "react";
@@ -38,9 +39,12 @@ export enum ScheduleGlanceType {
 export default function useScheduleGlance(schedule: Schedule, role: UserRole) {
   const { now, periodNumber, schoolSessionState } = useNow();
 
+  const mysk = useMySKClient();
+
   // Determine relevant periods every second
   const todayRow = useMemo(
-    () => (!isWeekend(now) ? schedule.content[now.getDay() - 1].content : []),
+    // () => (!isWeekend(now) ? schedule.content[now.getDay() - 1].content : []),
+    () => (!isWeekend(now) ? schedule.content[4].content : []),
     [schedule, now.getDay()],
   );
 
@@ -252,17 +256,38 @@ export default function useScheduleGlance(schedule: Schedule, role: UserRole) {
    * The period to display in the Schedule Glance.
    */
   const displayPeriod = useMemo(() => {
+    let displayPeriod: SchedulePeriod | undefined;
     switch (displayType) {
       case ScheduleGlanceType.learnCurrent:
       case ScheduleGlanceType.teachCurrent:
-        return currentPeriod;
+        displayPeriod = currentPeriod;
+        break;
       case ScheduleGlanceType.learnNext:
       case ScheduleGlanceType.teachTravel:
-        return immediateNextPeriod;
+        displayPeriod = immediateNextPeriod;
+        break;
       case ScheduleGlanceType.teachFuture:
-        return todayNextPeriod;
+        displayPeriod = todayNextPeriod;
+        break;
     }
-  }, [displayType]);
+
+    // If the student has chosen an Elective, only display that Elective.
+    if (
+      displayPeriod &&
+      displayPeriod.content.length > 1 &&
+      (mysk.person as Student)?.chosen_elective
+    )
+      return {
+        ...displayPeriod,
+        content: displayPeriod.content.filter(
+          (period) =>
+            period.subject.code.th ===
+            (mysk.person as Student).chosen_elective!.code.th,
+        ),
+      };
+
+    return displayPeriod;
+  }, [displayType, mysk.person]);
 
   /**
    * The number of minutes to display in the countdown.

--- a/utils/helpers/useNow.ts
+++ b/utils/helpers/useNow.ts
@@ -27,8 +27,8 @@ export default function useNow(
     return () => clearInterval(interval);
   }, []);
 
-  const periodNumber = periodNumberAt();
-  const schoolSessionState = schoolSessionStateAt();
+  const periodNumber = periodNumberAt(now);
+  const schoolSessionState = schoolSessionStateAt(now);
 
   return {
     /** The current time as a Date object. */

--- a/utils/helpers/useNow.ts
+++ b/utils/helpers/useNow.ts
@@ -27,8 +27,8 @@ export default function useNow(
     return () => clearInterval(interval);
   }, []);
 
-  const periodNumber = periodNumberAt(now);
-  const schoolSessionState = schoolSessionStateAt(now);
+  const periodNumber = periodNumberAt();
+  const schoolSessionState = schoolSessionStateAt();
 
   return {
     /** The current time as a Date object. */

--- a/utils/types/subject.ts
+++ b/utils/types/subject.ts
@@ -17,7 +17,7 @@ export type Subject = {
   id: string;
   code: Required<MultiLangString>;
   name: MultiLangString;
-  short_name: MultiLangString;
+  short_name: MultiLangString | null;
   type: SubjectTypeEnum;
   description?: MultiLangString;
   teachers: Teacher[];


### PR DESCRIPTION
![](https://github.com/suankularb-wittayalai-school/mysk-frontend/assets/26425747/2232ba2e-f4ce-4e67-8873-fcf4d508e8ce)

## Features
- Integrated Elective into Schedule
  Part of FRO-94
  - Only show chosen Elective in Schedule
    Resolves FRO-87
  - Only show chosen Elective in Schedule Glance
    Resolves FRO-95
- New Elective Period design
  Part of FRO-11
  - More Indicator under Elective Period distingushes it from Subject Period
  - Added an icon to indicate Elective Period
- Migrated to SKCom v3.3.2
  Resolves FRO-105

## Fixes
- Now Line sometimes throw hydration errors
  **Hint:** Try checking the console to see if there are any errors
- Elective Period throws when Teachers view a Classroom’s Schedule
  **Hint:** Log in as a Teacher and view a Classroom’s Schedule in the Classes page
- Hide seperator dot in Elective List Item if the Elective has no Teachers
  This can be seen in the Learn Electives page for M.301
- People Chip Set throws if the `people` prop is an empty array
  This can be seen in the Learn Electives page for M.301

## Code Changes
- Extracted Elective Grid Item component from Elective Grid
- Renamed `getSubjectName` to `formatSubjectPeriodName`

## Preview
This is the current main feature PR. Preview available at https://pr.mysk.school/.