### PR TITLE
[0.10.7] COVID-19 in Date Attendance

### DIFF
--- a/components/attendance/AbsenceTypeSelector.tsx
+++ b/components/attendance/AbsenceTypeSelector.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "next-i18next";
  * The text to put in the `absence_reason` field when the absence is due to
  * COVID-19.
  */
-export const COVID_REASON = "COVID-19";
+const COVID_REASON = "COVID-19";
 
 /**
  * A Chip Set for selecting an Absence Type.
@@ -46,7 +46,10 @@ const AbsenceTypeSelector: StylableFC<{
   return (
     <ChipSet scrollable style={style} className={className}>
       <FilterChip
-        selected={value === AbsenceType.sick}
+        selected={
+          value === AbsenceType.sick &&
+          attendance.absence_reason !== COVID_REASON
+        }
         onClick={() => handleTypeChange(AbsenceType.sick)}
       >
         {t("sick")}
@@ -57,7 +60,7 @@ const AbsenceTypeSelector: StylableFC<{
           onChange({
             ...attendance,
             is_present: false,
-            absence_type: AbsenceType.other,
+            absence_type: AbsenceType.sick,
             absence_reason: COVID_REASON,
           })
         }
@@ -83,10 +86,7 @@ const AbsenceTypeSelector: StylableFC<{
         {t("dropped")}
       </FilterChip>
       <FilterChip
-        selected={
-          value === AbsenceType.other &&
-          attendance.absence_reason !== COVID_REASON
-        }
+        selected={value === AbsenceType.other}
         onClick={() => handleTypeChange(AbsenceType.other)}
       >
         {t("other")}

--- a/components/attendance/AbsenceTypeSelector.tsx
+++ b/components/attendance/AbsenceTypeSelector.tsx
@@ -1,50 +1,93 @@
-// Imports
-import { AbsenceType } from "@/utils/types/attendance";
+import {
+  AbsenceType,
+  AttendanceEvent,
+  StudentAttendance,
+} from "@/utils/types/attendance";
 import { StylableFC } from "@/utils/types/common";
 import { ChipSet, FilterChip } from "@suankularb-components/react";
 import { useTranslation } from "next-i18next";
 
 /**
+ * The text to put in the `absence_reason` field when the absence is due to
+ * COVID-19.
+ */
+export const COVID_REASON = "COVID-19";
+
+/**
  * A Chip Set for selecting an Absence Type.
  *
- * @param value The currently selected Absence Type.
- * @param onChange Callback function to handle changes to the Absence Type.
+ * @param attendance The Student’s Attendance at an Attendance Event.
+ * @param onChange Triggers when the Attendance is changed. Should update the Attendance state.
  */
 const AbsenceTypeSelector: StylableFC<{
-  value: Exclude<AbsenceType, AbsenceType.late> | null;
-  onChange: (value: AbsenceType) => void;
-}> = ({ value, onChange, style, className }) => {
+  attendance: StudentAttendance[AttendanceEvent];
+  onChange: (attendance: StudentAttendance[AttendanceEvent]) => void;
+}> = ({ attendance, onChange, style, className }) => {
   const { t } = useTranslation("attendance", { keyPrefix: "item.absenceType" });
+
+  const value = attendance.absence_type;
+
+  /**
+   * Handles changing the Absence Type.
+   * @param type The new Absence Type.
+   */
+  function handleTypeChange(type: AbsenceType) {
+    onChange({
+      ...attendance,
+      is_present: false,
+      absence_type: type,
+      absence_reason:
+        attendance.absence_reason === COVID_REASON
+          ? null
+          : attendance.absence_reason,
+    });
+  }
 
   return (
     <ChipSet scrollable style={style} className={className}>
       <FilterChip
         selected={value === AbsenceType.sick}
-        onClick={() => onChange(AbsenceType.sick)}
+        onClick={() => handleTypeChange(AbsenceType.sick)}
       >
         {t("sick")}
       </FilterChip>
       <FilterChip
+        selected={attendance.absence_reason === COVID_REASON}
+        onClick={() =>
+          onChange({
+            ...attendance,
+            is_present: false,
+            absence_type: AbsenceType.other,
+            absence_reason: COVID_REASON,
+          })
+        }
+      >
+        {t("covid")}
+      </FilterChip>
+      <FilterChip
         selected={value === AbsenceType.business}
-        onClick={() => onChange(AbsenceType.business)}
+        onClick={() => handleTypeChange(AbsenceType.business)}
       >
         {t("business")}
       </FilterChip>
       <FilterChip
         selected={value === AbsenceType.absent}
-        onClick={() => onChange(AbsenceType.absent)}
+        onClick={() => handleTypeChange(AbsenceType.absent)}
       >
         {t("absent")}
       </FilterChip>
       <FilterChip
         selected={value === AbsenceType.dropped}
-        onClick={() => onChange(AbsenceType.dropped)}
+        onClick={() => handleTypeChange(AbsenceType.dropped)}
       >
         {t("dropped")}
       </FilterChip>
       <FilterChip
-        selected={value === AbsenceType.other}
-        onClick={() => onChange(AbsenceType.other)}
+        selected={
+          value === AbsenceType.other &&
+          attendance.absence_reason !== COVID_REASON
+        }
+        onClick={() => handleTypeChange(AbsenceType.other)}
       >
         {t("other")}
       </FilterChip>

--- a/components/attendance/AttendanceBulkActions.tsx
+++ b/components/attendance/AttendanceBulkActions.tsx
@@ -1,6 +1,7 @@
 import SnackbarContext from "@/contexts/SnackbarContext";
 import bulkCreateAttendanceOfClass from "@/utils/backend/attendance/bulkCreateAttendanceOfClass";
 import clearAttendanceOfClass from "@/utils/backend/attendance/clearAttendanceOfClass";
+import useMySKClient from "@/utils/backend/mysk/useMySKClient";
 import cn from "@/utils/helpers/cn";
 import useRefreshProps from "@/utils/helpers/useRefreshProps";
 import withLoading from "@/utils/helpers/withLoading";
@@ -32,7 +33,6 @@ import { useContext } from "react";
  * @param toggleLoading Callback to toggle loading state during saving.
  * @param date The date of the Attendance. Used in saving.
  * @param classroom The Classroom that this page is for. Used in saving.
- * @param teacherID The ID of the Teacher who is viewing this page. Used in saving.
  */
 const AttendanceBulkActions: StylableFC<{
   attendances: StudentAttendance[];
@@ -40,22 +40,21 @@ const AttendanceBulkActions: StylableFC<{
   toggleLoading: () => void;
   date: string;
   classroom: Pick<Classroom, "id" | "number">;
-  teacherID: string;
 }> = ({
   attendances,
   onAttendancesChange,
   toggleLoading,
   date,
   classroom,
-  teacherID,
   style,
   className,
 }) => {
   const { t } = useTranslation("attendance", { keyPrefix: "day" });
   const { t: tx } = useTranslation("common");
 
-  const supabase = useSupabaseClient();
   const plausible = usePlausible();
+  const supabase = useSupabaseClient();
+  const mysk = useMySKClient();
   const { setSnackbar } = useContext(SnackbarContext);
   const refreshProps = useRefreshProps();
 
@@ -75,7 +74,7 @@ const AttendanceBulkActions: StylableFC<{
           supabase,
           date,
           classroom.id,
-          teacherID,
+          mysk.person!.id,
         );
         if (error) setSnackbar(<Snackbar>{tx("snackbar.failure")}</Snackbar>);
         else await refreshProps();

--- a/components/attendance/AttendanceBulkActions.tsx
+++ b/components/attendance/AttendanceBulkActions.tsx
@@ -131,14 +131,14 @@ const AttendanceBulkActions: StylableFC<{
       transition={transition(DURATION.medium2, EASING.standard)}
       style={style}
       className={cn(
-        `overflow-auto !rounded-none !bg-surface px-0 sm:px-4 md:-mx-4
+        `overflow-auto !rounded-none !bg-surface px-0 md:-mx-2
         md:!bg-transparent`,
         className,
       )}
     >
       <Actions
         align="left"
-        className={cn(`!w-fit !flex-nowrap md:!gap-1 md:px-4 *:md:!border-0
+        className={cn(`!w-fit !flex-nowrap md:!gap-1 md:px-2 *:md:!border-0
           *:md:!bg-surface [&>*>span]:whitespace-nowrap`)}
       >
         <Button

--- a/components/attendance/AttendanceListItem.tsx
+++ b/components/attendance/AttendanceListItem.tsx
@@ -1,4 +1,5 @@
 import AbsenceTypeSelector from "@/components/attendance/AbsenceTypeSelector";
+import LateChip from "@/components/attendance/LateChip";
 import PersonAvatar from "@/components/common/PersonAvatar";
 import SnackbarContext from "@/contexts/SnackbarContext";
 import upsertAttendance from "@/utils/backend/attendance/upsertAttendance";
@@ -18,7 +19,6 @@ import {
   Button,
   DURATION,
   EASING,
-  FilterChip,
   ListItem,
   ListItemContent,
   MaterialIcon,
@@ -31,6 +31,7 @@ import { motion } from "framer-motion";
 import { useTranslation } from "next-i18next";
 import { sift } from "radash";
 import { ComponentProps, useContext } from "react";
+import { UserRole } from "@/utils/types/person";
 
 /**
  * A List Item for the Attendance page.
@@ -172,7 +173,12 @@ const AttendanceListItem: StylableFC<{
         className={cn(`grid w-full py-1`, loading && `animate-pulse`)}
       >
         {/* Student information */}
-        <ListItem key={attendance.student.id} align="center" lines={2}>
+        <ListItem
+          align="center"
+          lines={2}
+          element="div"
+          className="!items-center !overflow-visible"
+        >
           <PersonAvatar
             {...attendance.student}
             expandable
@@ -190,23 +196,12 @@ const AttendanceListItem: StylableFC<{
           />
 
           {/* Late */}
-          {shownEvent === "assembly" &&
-            (attendance.assembly.is_present ||
-              attendance.assembly.absence_type === "late") && (
-              <FilterChip
-                selected={attendance.assembly.absence_type === "late"}
-                onClick={(state) =>
-                  setAttendanceOfShownEvent({
-                    ...attendance.assembly,
-                    ...(state
-                      ? { is_present: false, absence_type: AbsenceType.late }
-                      : { is_present: true, absence_type: null }),
-                  })
-                }
-              >
-                {t("late")}
-              </FilterChip>
-            )}
+          {shownEvent === "assembly" && (
+            <LateChip
+              attendance={attendance[shownEvent]}
+              onChange={setAttendanceOfShownEvent}
+            />
+          )}
 
           {/* Presence */}
           <Button

--- a/components/attendance/AttendanceListItem.tsx
+++ b/components/attendance/AttendanceListItem.tsx
@@ -1,8 +1,12 @@
-import AbsenceTypeSelector from "@/components/attendance/AbsenceTypeSelector";
+import AbsenceTypeSelector, {
+  COVID_REASON,
+} from "@/components/attendance/AbsenceTypeSelector";
 import LateChip from "@/components/attendance/LateChip";
 import PersonAvatar from "@/components/common/PersonAvatar";
+import WithPersonDetails from "@/components/person/WithPersonDetails";
 import SnackbarContext from "@/contexts/SnackbarContext";
 import upsertAttendance from "@/utils/backend/attendance/upsertAttendance";
+import useMySKClient from "@/utils/backend/mysk/useMySKClient";
 import cn from "@/utils/helpers/cn";
 import getLocaleName from "@/utils/helpers/getLocaleName";
 import getLocaleString from "@/utils/helpers/getLocaleString";
@@ -16,7 +20,6 @@ import {
 } from "@/utils/types/attendance";
 import { StylableFC } from "@/utils/types/common";
 import { UserRole } from "@/utils/types/person";
-import WithPersonDetails from "@/components/person/WithPersonDetails";
 import {
   Button,
   DURATION,
@@ -33,7 +36,7 @@ import { useSupabaseClient } from "@supabase/auth-helpers-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "next-i18next";
 import { sift } from "radash";
-import { ComponentProps, useContext, useState } from "react";
+import { useContext, useState } from "react";
 
 /**
  * A List Item for the Attendance page.
@@ -249,46 +252,37 @@ const AttendanceListItem: StylableFC<{
 
         {/* Absence type */}
         {attendance[shownEvent].absence_type &&
-          attendance[shownEvent].absence_type !== "late" && (
+          attendance[shownEvent].absence_type !== AbsenceType.late && (
             <AbsenceTypeSelector
-              value={
-                attendance[shownEvent].absence_type as ComponentProps<
-                  typeof AbsenceTypeSelector
-                >["value"]
-              }
-              onChange={(absence_type) => {
-                setAttendanceOfShownEvent({
-                  ...attendance[shownEvent],
-                  is_present: false,
-                  absence_type,
-                });
-              }}
+              attendance={attendance[shownEvent]}
+              onChange={setAttendanceOfShownEvent}
               className="mb-2 *:px-4"
             />
           )}
 
         {/* Custom reason */}
-        {attendance[shownEvent].absence_type === "other" && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={transition(DURATION.medium2, EASING.standard)}
-            className="mt-1 px-4 sm:pb-2"
-          >
-            <TextField<string>
-              appearance="outlined"
-              label={t("enterReason")}
-              value={attendance[shownEvent].absence_reason || ""}
-              onChange={(absence_reason) => {
-                setAttendanceOfShownEvent({
-                  ...attendance[shownEvent],
-                  absence_reason,
-                });
-              }}
-              inputAttr={{ onBlur: () => handleSave(attendance) }}
-            />
-          </motion.div>
-        )}
+        {attendance[shownEvent].absence_type === "other" &&
+          attendance[shownEvent].absence_reason !== COVID_REASON && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={transition(DURATION.medium2, EASING.standard)}
+              className="mt-1 px-4 sm:pb-2"
+            >
+              <TextField<string>
+                appearance="outlined"
+                label={t("enterReason")}
+                value={attendance[shownEvent].absence_reason || ""}
+                onChange={(absence_reason) => {
+                  setAttendanceOfShownEvent({
+                    ...attendance[shownEvent],
+                    absence_reason,
+                  });
+                }}
+                inputAttr={{ onBlur: () => handleSave(attendance) }}
+              />
+            </motion.div>
+          )}
       </motion.ul>
     </motion.li>
   );

--- a/components/attendance/AttendanceListItem.tsx
+++ b/components/attendance/AttendanceListItem.tsx
@@ -15,10 +15,13 @@ import {
   StudentAttendance,
 } from "@/utils/types/attendance";
 import { StylableFC } from "@/utils/types/common";
+import { UserRole } from "@/utils/types/person";
+import WithPersonDetails from "@/components/person/WithPersonDetails";
 import {
   Button,
   DURATION,
   EASING,
+  Interactive,
   ListItem,
   ListItemContent,
   MaterialIcon,
@@ -30,8 +33,7 @@ import { useSupabaseClient } from "@supabase/auth-helpers-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "next-i18next";
 import { sift } from "radash";
-import { ComponentProps, useContext } from "react";
-import { UserRole } from "@/utils/types/person";
+import { ComponentProps, useContext, useState } from "react";
 
 /**
  * A List Item for the Attendance page.
@@ -63,9 +65,10 @@ const AttendanceListItem: StylableFC<{
   const { t: tx } = useTranslation("common");
 
   const supabase = useSupabaseClient();
+  const { setSnackbar } = useContext(SnackbarContext);
 
   const [loading, toggleLoading] = useToggle();
-  const { setSnackbar } = useContext(SnackbarContext);
+  const [studentOpen, setStudentOpen] = useState(false);
 
   /**
    * Whether to show the Checkbox as ticked [✓], crossed [✕], or empty [ ].
@@ -179,11 +182,19 @@ const AttendanceListItem: StylableFC<{
           element="div"
           className="!items-center !overflow-visible"
         >
-          <PersonAvatar
-            {...attendance.student}
-            expandable
-            className="!min-w-[2.5rem]"
-          />
+          <WithPersonDetails
+            open={studentOpen}
+            person={{ ...attendance.student, role: UserRole.student }}
+            onClose={() => setStudentOpen(false)}
+            options={{ hideSeeClass: true }}
+          >
+            <Interactive
+              onClick={() => setStudentOpen(true)}
+              className="-m-1 rounded-full p-1"
+            >
+              <PersonAvatar {...attendance.student} size={40} />
+            </Interactive>
+          </WithPersonDetails>
           <ListItemContent
             title={getLocaleName(locale, attendance.student)}
             desc={sift([

--- a/components/attendance/AttendanceListItem.tsx
+++ b/components/attendance/AttendanceListItem.tsx
@@ -1,6 +1,4 @@
-import AbsenceTypeSelector, {
-  COVID_REASON,
-} from "@/components/attendance/AbsenceTypeSelector";
+import AbsenceTypeSelector from "@/components/attendance/AbsenceTypeSelector";
 import LateChip from "@/components/attendance/LateChip";
 import PersonAvatar from "@/components/common/PersonAvatar";
 import WithPersonDetails from "@/components/person/WithPersonDetails";
@@ -253,28 +251,27 @@ const AttendanceListItem: StylableFC<{
           )}
 
         {/* Custom reason */}
-        {attendance[shownEvent].absence_type === "other" &&
-          attendance[shownEvent].absence_reason !== COVID_REASON && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={transition(DURATION.medium2, EASING.standard)}
-              className="mt-1 px-4 sm:pb-2"
-            >
-              <TextField<string>
-                appearance="outlined"
-                label={t("enterReason")}
-                value={attendance[shownEvent].absence_reason || ""}
-                onChange={(absence_reason) => {
-                  setAttendanceOfShownEvent({
-                    ...attendance[shownEvent],
-                    absence_reason,
-                  });
-                }}
-                inputAttr={{ onBlur: () => handleSave(attendance) }}
-              />
-            </motion.div>
-          )}
+        {attendance[shownEvent].absence_type === "other" && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={transition(DURATION.medium2, EASING.standard)}
+            className="mt-1 px-4 sm:pb-2"
+          >
+            <TextField<string>
+              appearance="outlined"
+              label={t("enterReason")}
+              value={attendance[shownEvent].absence_reason || ""}
+              onChange={(absence_reason) => {
+                setAttendanceOfShownEvent({
+                  ...attendance[shownEvent],
+                  absence_reason,
+                });
+              }}
+              inputAttr={{ onBlur: () => handleSave(attendance) }}
+            />
+          </motion.div>
+        )}
       </motion.ul>
     </motion.li>
   );

--- a/components/attendance/HomeroomContentDialog.tsx
+++ b/components/attendance/HomeroomContentDialog.tsx
@@ -43,6 +43,7 @@ const HomeroomContentDialog: StylableFC<{
           value={field}
           onChange={setField}
           inputAttr={{ readOnly: loading }}
+          className="[&_textarea]:min-h-32"
         />
       </DialogContent>
       <Actions>

--- a/components/attendance/HomeroomContentEditor.tsx
+++ b/components/attendance/HomeroomContentEditor.tsx
@@ -42,6 +42,7 @@ const HomeroomContentEditor: FC<{
         value={field}
         onChange={setField}
         inputAttr={{ readOnly: loading }}
+        className="[&_textarea]:min-h-32"
       />
       <Actions>
         <Button appearance="text" onClick={handleCancel}>

--- a/components/attendance/LateChip.tsx
+++ b/components/attendance/LateChip.tsx
@@ -1,0 +1,82 @@
+import cn from "@/utils/helpers/cn";
+import useToggle from "@/utils/helpers/useToggle";
+import { AbsenceType, StudentAttendance } from "@/utils/types/attendance";
+import { StylableFC } from "@/utils/types/common";
+import {
+  FilterChip,
+  MaterialIcon,
+  Menu,
+  MenuItem,
+} from "@suankularb-components/react";
+import { useTranslation } from "next-i18next";
+
+/**
+ * A Chip to toggle between a Student being late or on time.
+ *
+ * @param attendance The Student’s Attendance at assembly.
+ * @param onChange Triggers when the Attendance is changed. Should update the Attendance state.
+ */
+const LateChip: StylableFC<{
+  attendance: StudentAttendance["assembly"];
+  onChange: (attendance: StudentAttendance["assembly"]) => void;
+}> = ({ attendance, onChange, style, className }) => {
+  const { t } = useTranslation("attendance", { keyPrefix: "item.lateChip" });
+
+  const late = attendance.absence_type === AbsenceType.late;
+  const [menuOpen, toggleMenuOpen] = useToggle();
+
+  /** `onChange` with the new Student Attendance. */
+  function toggleLate() {
+    onChange({
+      ...attendance,
+      ...(!late // If not late, then make late.
+        ? { is_present: false, absence_type: AbsenceType.late }
+        : // If late, then make present.
+          { is_present: true, absence_type: null }),
+    });
+  }
+
+  if (!(attendance.is_present || attendance.absence_type === AbsenceType.late))
+    return null;
+
+  return (
+    <FilterChip
+      selected={late}
+      onClick={toggleLate}
+      onMenuToggle={toggleMenuOpen}
+      menu={
+        <Menu open={menuOpen} density={-4} className="!left-auto !min-w-40">
+          <MenuItem
+            icon={<MaterialIcon icon="done" />}
+            selected={!late}
+            onClick={() => {
+              if (late) toggleLate();
+              toggleMenuOpen();
+            }}
+          >
+            {t("onTime")}
+          </MenuItem>
+          <MenuItem
+            icon={<MaterialIcon icon="alarm" />}
+            selected={late}
+            onClick={() => {
+              if (!late) toggleLate();
+              toggleMenuOpen();
+            }}
+          >
+            {t("late")}
+          </MenuItem>
+        </Menu>
+      }
+      style={style}
+      className={cn(
+        String.raw`!pl-4 [&>.skc-filter-chip\_\_icon]:!hidden`,
+        className,
+      )}
+    >
+      {late ? t("late") : t("onTime")}
+    </FilterChip>
+  );
+};
+
+export default LateChip;

--- a/pages/classes/[classNumber]/attendance/date/[date].tsx
+++ b/pages/classes/[classNumber]/attendance/date/[date].tsx
@@ -259,6 +259,7 @@ export const getServerSideProps: GetServerSideProps = async ({
       ...(await serverSideTranslations(locale as LangCode, [
         "common",
         "attendance",
+        "lookup",
       ])),
       date,
       attendances,

--- a/pages/classes/[classNumber]/attendance/date/[date].tsx
+++ b/pages/classes/[classNumber]/attendance/date/[date].tsx
@@ -176,7 +176,6 @@ const DateAttendancePage: CustomPage<{
                   attendance={attendance}
                   shownEvent={event}
                   date={date}
-                  teacherID={mysk.person?.id}
                   editable={editable && !loading}
                   onAttendanceChange={(attendance) =>
                     setAttendances(
@@ -198,7 +197,6 @@ const DateAttendancePage: CustomPage<{
                   toggleLoading={toggleLoading}
                   date={date}
                   classroom={classroom}
-                  teacherID={mysk.person?.id}
                   className="mt-2 px-4 md:px-0"
                 />
               )}

--- a/public/static/locales/en-US/attendance.json
+++ b/public/static/locales/en-US/attendance.json
@@ -57,6 +57,7 @@
     },
     "absenceType": {
       "sick": "Sick",
+      "covid": "COVID-19",
       "business": "Personal",
       "absent": "Absent",
       "dropped": "Dropped",

--- a/public/static/locales/en-US/attendance.json
+++ b/public/static/locales/en-US/attendance.json
@@ -51,7 +51,10 @@
   },
   "item": {
     "classNo": "No. {{classNo}}",
-    "late": "Late",
+    "lateChip": {
+      "onTime": "On time",
+      "late": "Late"
+    },
     "absenceType": {
       "sick": "Sick",
       "business": "Personal",

--- a/public/static/locales/th/attendance.json
+++ b/public/static/locales/th/attendance.json
@@ -50,7 +50,10 @@
   },
   "item": {
     "classNo": "เลขที่ {{classNo}}",
-    "late": "สาย",
+    "lateChip": {
+      "onTime": "ทัน",
+      "late": "สาย"
+    },
     "absenceType": {
       "sick": "ลาป่วย",
       "business": "ลากิจ",

--- a/public/static/locales/th/attendance.json
+++ b/public/static/locales/th/attendance.json
@@ -56,6 +56,7 @@
     },
     "absenceType": {
       "sick": "ลาป่วย",
+      "covid": "โควิด-19",
       "business": "ลากิจ",
       "absent": "ขาดไม่มีเหตุ",
       "dropped": "พักการเรียน",


### PR DESCRIPTION
![](https://github.com/suankularb-wittayalai-school/mysk-frontend/assets/26425747/b7e6f2e2-a1b7-4151-a812-cc47096e8e02)

## Features
- COVID-19 Chip
  Part of FRO-174 [(link)](https://linear.app/skiso/issue/FRO-174/covid-absence-type-selection)
- Late Chip
  - Dropdown Menu for selecting on time and late
- With Person Details in Attendance List Item
- Increased height of Text Field for Homeroom Content
  - This is to let the users know that the field is not single-line

## Fixes
- Attendance Bulk Actions causes the list side of Date Attendance to scroll horizontally

## Code Changes
- Replaced `teacherID` prop with `useMySKClient`

## Preview
Preview available at https://pr1.mysk.school/.