### PR TITLE
Feat/0.11.1/disable previously selected subject

### DIFF
--- a/components/elective/ElectiveListItem.tsx
+++ b/components/elective/ElectiveListItem.tsx
@@ -24,6 +24,7 @@ import { sort } from "radash";
  * @param electiveSubject The Elective Subject to display.
  * @param selected Whether this Elective Subject is selected.
  * @param enrolled Whether the Student is enrolled in the Elective Subject.
+ * @param previouslyEnrolled Whether the Student has enrolled before.
  * @param onRadioToggle Triggers when the radio button is toggled.
  */
 const ElectiveListItem: StylableFC<{
@@ -31,12 +32,14 @@ const ElectiveListItem: StylableFC<{
   electiveSubject: ElectiveSubject;
   selected?: boolean;
   enrolled?: boolean;
+  previouslyEnrolled?: boolean
   onClick?: () => void;
 }> = ({
   role,
   electiveSubject,
   selected,
   enrolled,
+  previouslyEnrolled,
   onClick,
   style,
   className,
@@ -71,7 +74,7 @@ const ElectiveListItem: StylableFC<{
     >
       {/* Radio */}
       {role === UserRole.student &&
-        (enrolled ? (
+        ((enrolled && (previouslyEnrolled == false)) ? (
           <MaterialIcon
             icon="check"
             fill
@@ -80,7 +83,10 @@ const ElectiveListItem: StylableFC<{
         ) : (
           <Radio
             value={selected}
-            disabled={electiveSubject.class_size >= electiveSubject.cap_size}
+            disabled={
+              electiveSubject.class_size >= electiveSubject.cap_size || 
+              previouslyEnrolled == true
+            }
             inputAttr={{ name: "elective" }}
             className="py-3"
           />
@@ -91,7 +97,10 @@ const ElectiveListItem: StylableFC<{
         className={role === UserRole.teacher ? "grid grow gap-3" : "contents"}
       >
         <ListItemContent
-          overline={enrolled ? t("enrolled") : undefined}
+          overline={
+            previouslyEnrolled ? t("previouslyEnrolled") : 
+            (enrolled ? t("enrolled") : undefined)
+          }
           title={getLocaleString(electiveSubject.name, locale)}
           desc={
             <>

--- a/pages/classes/[classNumber]/attendance/month/[date].tsx
+++ b/pages/classes/[classNumber]/attendance/month/[date].tsx
@@ -19,6 +19,8 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Head from "next/head";
 import { group } from "radash";
 
+let invalidDate = false;
+
 /**
  * Month Attendance page displays Attendance of a Classroom of a specific month.
  * 
@@ -49,6 +51,7 @@ const MonthAttendancePage: CustomPage<{
       <PageHeader parentURL="/classes">
         {t("title", { classNumber: classroom.number })}
       </PageHeader>
+      
       <ContentLayout>
         <AttendanceViewSelector
           view={AttendanceView.month}

--- a/pages/learn/electives.tsx
+++ b/pages/learn/electives.tsx
@@ -79,9 +79,6 @@ const LearnElectivesPage: CustomPage<{
       }),
     { dialogBreakpoints: DIALOG_BREAKPOINTS },
   );
-  console.log(electiveSubjects);
-  console.log(previouslyEnrolled);
-  
 
   return (
     <>
@@ -103,7 +100,7 @@ const LearnElectivesPage: CustomPage<{
                   previouslyEnrolled={
                     // Change to actual check when API's available
                     electiveSubject?.id == previouslyEnrolled[0]
-                  } 
+                  }
                   onClick={() => {
                     plausible("View Elective", {
                       props: {
@@ -216,7 +213,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     { data: electiveSubjects },
     { data: enrolledElectiveSubjects },
     { data: inEnrollmentPeriod },
-    { data: previouslyEnrolled }
+    { data: previouslyEnrolled },
   ] = await Promise.all([
     // Get the list of Elective Subjects available for this Student to enroll in.
     await mysk.fetch<ElectiveSubject[]>("/v1/subjects/electives", {
@@ -246,7 +243,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     // Check if the time now is in an Enrollment Period.
     await mysk.fetch<boolean>("/v1/subjects/electives/in-enrollment-period"),
 
-    await mysk.fetch("/v1/subjects/electives/previously-enrolled")
+    await mysk.fetch("/v1/subjects/electives/previously-enrolled"),
   ]);
 
   // If there are no Elective Subjects available, return a 404.

--- a/public/static/locales/en-US/elective.json
+++ b/public/static/locales/en-US/elective.json
@@ -5,6 +5,7 @@
   "list": {
     "searchAlt": "Search electives",
     "enrolled": "Currently enrolled",
+    "previouslyEnrolled": "Previously enrolled",
     "enrollment": {
       "alt": "{{count}} enrolled out of {{max}}",
       "label": "<0>{{count}}</0>/{{max}}",

--- a/public/static/locales/th/elective.json
+++ b/public/static/locales/th/elective.json
@@ -5,6 +5,7 @@
   "list": {
     "searchAlt": "ค้นหาวิชาเลือก",
     "enrolled": "ที่ลงทะเบียนอยู่",
+    "previouslyEnrolled": "เคยเรียนแล้ว",
     "enrollment": {
       "alt": "ลงทะเบียนแล้ว {{count}} คน จาก {{max}} คน",
       "label": "<0>{{count}}</0>/{{max}}",


### PR DESCRIPTION
| ![localhost_3000_learn_electives(iPad Air)](https://github.com/user-attachments/assets/bd8f6ba4-d7e6-441d-8e66-1d24caac8b97) |
| --- |

**Features**
- Disable previously selected subject on last semester.
  Resolves [FRO-208](https://linear.app/skiso/issue/FRO-209/disable-subject-previously-selected-on-semester-1)
